### PR TITLE
fix(plugin-vue): don't inline template when `__VUE_PROD_DEVTOOLS__`

### DIFF
--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -79,7 +79,8 @@ export async function transformMain(
 
   // template
   const hasTemplateImport =
-    descriptor.template && !isUseInlineTemplate(descriptor, !devServer)
+    descriptor.template &&
+    !isUseInlineTemplate(descriptor, !devServer && !devToolsEnabled)
 
   let templateCode = ''
   let templateMap: RawSourceMap | undefined = undefined

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -79,8 +79,7 @@ export async function transformMain(
 
   // template
   const hasTemplateImport =
-    descriptor.template &&
-    !isUseInlineTemplate(descriptor, !devServer && !devToolsEnabled)
+    descriptor.template && !isUseInlineTemplate(descriptor, options)
 
   let templateCode = ''
   let templateMap: RawSourceMap | undefined = undefined

--- a/packages/plugin-vue/src/script.ts
+++ b/packages/plugin-vue/src/script.ts
@@ -37,9 +37,14 @@ export function setResolvedScript(
 // inlined template cannot be individually hot updated.
 export function isUseInlineTemplate(
   descriptor: SFCDescriptor,
-  isProd: boolean,
+  options: ResolvedOptions,
 ): boolean {
-  return isProd && !!descriptor.scriptSetup && !descriptor.template?.src
+  return (
+    !options.devServer &&
+    !options.devToolsEnabled &&
+    !!descriptor.scriptSetup &&
+    !descriptor.template?.src
+  )
 }
 
 export const scriptIdentifier = `_sfc_main`
@@ -65,10 +70,7 @@ export function resolveScript(
     ...options.script,
     id: descriptor.id,
     isProd: options.isProduction,
-    inlineTemplate: isUseInlineTemplate(
-      descriptor,
-      !options.devServer && !options.devToolsEnabled,
-    ),
+    inlineTemplate: isUseInlineTemplate(descriptor, options),
     templateOptions: resolveTemplateCompilerOptions(descriptor, options, ssr),
     sourceMap: options.sourceMap,
     genDefaultAs: canInlineMain(descriptor, options)

--- a/packages/plugin-vue/src/script.ts
+++ b/packages/plugin-vue/src/script.ts
@@ -65,7 +65,10 @@ export function resolveScript(
     ...options.script,
     id: descriptor.id,
     isProd: options.isProduction,
-    inlineTemplate: isUseInlineTemplate(descriptor, !options.devServer),
+    inlineTemplate: isUseInlineTemplate(
+      descriptor,
+      !options.devServer && !options.devToolsEnabled,
+    ),
     templateOptions: resolveTemplateCompilerOptions(descriptor, options, ssr),
     sourceMap: options.sourceMap,
     genDefaultAs: canInlineMain(descriptor, options)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Ensure that the `setup` section is available in Vuejs Devtools when building with `__VUE_PROD_DEVTOOLS__: true`.

### Additional context
Original fix. Possible regression since then? https://github.com/vitejs/vite/pull/4984
Another report with example reproduction: https://github.com/vuejs/devtools/issues/1940

Not sure if `defineExpose` is supposed to play a role here.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite-plugin-vue/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
