### PR TITLE
fix(plugin-vue): hmr not working when updating script+template at the same time with a template preprocessor

### DIFF
--- a/packages/plugin-vue/src/template.ts
+++ b/packages/plugin-vue/src/template.ts
@@ -7,7 +7,7 @@ import type {
   SFCTemplateCompileResults,
 } from 'vue/compiler-sfc'
 import type { PluginContext, TransformPluginContext } from 'rollup'
-import { getResolvedScript } from './script'
+import { getResolvedScript, resolveScript } from './script'
 import { createRollupError } from './utils/error'
 import type { ResolvedOptions } from '.'
 
@@ -68,6 +68,7 @@ export function compile(
   ssr: boolean,
 ) {
   const filename = descriptor.filename
+  resolveScript(descriptor, options, ssr)
   const result = options.compiler.compileTemplate({
     ...resolveTemplateCompilerOptions(descriptor, options, ssr)!,
     source: code,

--- a/playground/vue/Main.vue
+++ b/playground/vue/Main.vue
@@ -10,6 +10,7 @@
   </div>
   <Syntax />
   <PreProcessors />
+  <PreProcessorsHmr />
   <CssModules />
   <Assets />
   <CustomBlock />
@@ -33,6 +34,7 @@ import Hmr from './Hmr.vue'
 import HmrTsx from './HmrTsx.vue'
 import Syntax from './Syntax.vue'
 import PreProcessors from './PreProcessors.vue'
+import PreProcessorsHmr from './PreProcessorsHmr.vue'
 import CssModules from './CssModules.vue'
 import Assets from './Assets.vue'
 import CustomBlock from './CustomBlock.vue'

--- a/playground/vue/PreProcessorsHmr.vue
+++ b/playground/vue/PreProcessorsHmr.vue
@@ -1,0 +1,8 @@
+<template lang="pug">
+h2.pre-processors-hmr Pre-Processors Hmr
+p.pug-hmr {{ preHmr }}
+</template>
+
+<script setup>
+const preHmr = 'pre-hmr'
+</script>

--- a/playground/vue/__tests__/vue.spec.ts
+++ b/playground/vue/__tests__/vue.spec.ts
@@ -94,6 +94,16 @@ describe('pre-processors', () => {
     )
     await untilUpdated(() => getColor('p.pug-stylus'), 'orange')
   })
+
+  test('pug hmr', async () => {
+    expect(await page.textContent('p.pug-hmr')).toMatch('pre-hmr')
+    editFile('PreProcessorsHmr.vue', (code) =>
+      code
+        .replace('p.pug-hmr {{ preHmr }}', 'p.pug-hmr {{ postHmr }}')
+        .replace(`const preHmr = 'pre-hmr'`, `const postHmr = 'post-hmr'`),
+    )
+    await untilUpdated(() => page.textContent('p.pug-hmr'), 'post-hmr')
+  })
 })
 
 describe('css modules', () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #28 and #76.

When using pug as a template preprocessor and if you update both script and template at the same time, you will get

```
Property "foo" was accessed during render but is not defined on instance.
```

as a browser console error instead of hmr updating properly.
This is because the template compilation relies on the compiled script being already in cache, which in this case it isn't, because the hmr requests both template and script modules at the same time (see #28 for timing).

This fix makes sure that the script cache is always populated before the template is compiled.

### Additional context

I'm not sure if calling `resolveScript` on every template `compile` is overkill, but `resolveScript` has an early return if there is already cached result. I could not get the relevant context ("template+script update at same time") on compile time, since this information is lost when the hmr client makes two separate requests.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite-plugin-vue/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
