### PR TITLE
chore: skip sourcemap tests after vitejs/vite/pull/12079

### DIFF
--- a/playground/vue-sourcemap/__tests__/vue-sourcemap.spec.ts
+++ b/playground/vue-sourcemap/__tests__/vue-sourcemap.spec.ts
@@ -21,14 +21,16 @@ describe.runIf(isServe)('serve:vue-sourcemap', () => {
     throw new Error('Style not found: ' + content)
   }
 
-  test('js', async () => {
+  // Temporal skip after https://github.com/vitejs/vite/pull/12079
+  test.skip('js', async () => {
     const res = await page.request.get(new URL('./Js.vue', page.url()).href)
     const js = await res.text()
     const map = extractSourcemap(js)
     expect(formatSourcemapForSnapshot(map)).toMatchSnapshot('serve-js')
   })
 
-  test('ts', async () => {
+  // Temporal skip after https://github.com/vitejs/vite/pull/12079
+  test.skip('ts', async () => {
     const res = await page.request.get(new URL('./Ts.vue', page.url()).href)
     const js = await res.text()
     const map = extractSourcemap(js)
@@ -91,7 +93,8 @@ describe.runIf(isServe)('serve:vue-sourcemap', () => {
     )
   })
 
-  test('no script', async () => {
+  // Temporal skip after https://github.com/vitejs/vite/pull/12079
+  test.skip('no script', async () => {
     const res = await page.request.get(
       new URL('./NoScript.vue', page.url()).href,
     )
@@ -100,7 +103,8 @@ describe.runIf(isServe)('serve:vue-sourcemap', () => {
     expect(formatSourcemapForSnapshot(map)).toMatchSnapshot('serve-no-script')
   })
 
-  test('no template', async () => {
+  // Temporal skip after https://github.com/vitejs/vite/pull/12079
+  test.skip('no template', async () => {
     const res = await page.request.get(
       new URL('./NoTemplate.vue', page.url()).href,
     )


### PR DESCRIPTION
### Description

Temporal skip of outdated sourcemaps to avoid false negatives on ecosystem-ci after 
- https://github.com/vitejs/vite/pull/12079

Reference run of plugin-vue: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/4300266958/jobs/7496308552

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
