### PR TITLE
支持添加在 @babel/plugin-transform-typescript 后运行的 babel 插件

### DIFF
--- a/packages/plugin-vue-jsx/src/index.ts
+++ b/packages/plugin-vue-jsx/src/index.ts
@@ -38,7 +38,7 @@ function vueJsxPlugin(options: Options = {}): Plugin {
   let needHmr = false
   let needSourceMap = true
 
-  const { include, exclude, babelPlugins = [], ...babelPluginOptions } = options
+  const { include, exclude, babelPlugins = [], babalPluginsAfterTsTransform = [], ...babelPluginOptions } = options
   const filter = createFilter(include || /\.[jt]sx$/, exclude)
 
   return {
@@ -93,6 +93,7 @@ function vueJsxPlugin(options: Options = {}): Plugin {
             // @ts-ignore
             { isTSX: true, allowExtensions: true },
           ])
+          plugins.push(...babalPluginsAfterTsTransform)
         }
 
         if (!ssr && !needHmr) {

--- a/packages/plugin-vue-jsx/src/types.ts
+++ b/packages/plugin-vue-jsx/src/types.ts
@@ -7,4 +7,4 @@ export interface FilterOptions {
 }
 
 export type Options = VueJSXPluginOptions &
-  FilterOptions & { babelPlugins?: any[] }
+  FilterOptions & { babelPlugins?: any[], babalPluginsAfterTsTransform?: any[] }


### PR DESCRIPTION
我添加了一个名为 babelPluginsAfterTsTransform 的选项，可以让使用者添加在 @babel/plugin-transform-typescript 后运行的 babel 插件