### PR TITLE
fix: add `defineModel` and `propsDestructure` options

### DIFF
--- a/packages/plugin-vue/README.md
+++ b/packages/plugin-vue/README.md
@@ -59,6 +59,20 @@ export interface Options {
   reactivityTransform?: boolean | string | RegExp | (string | RegExp)[]
 
   /**
+   * Enable `defineModel` macro (experimental).
+   * https://github.com/vuejs/rfcs/discussions/503
+   * @default false
+   */
+  defineModel?: boolean
+
+  /**
+   * Enable reactive props destructure (experimental).
+   * https://github.com/vuejs/rfcs/discussions/502
+   * @default false
+   */
+  propsDestructure?: boolean
+
+  /**
    * Use custom compiler-sfc instance. Can be used to force a specific version.
    */
   compiler?: typeof _compiler

--- a/packages/plugin-vue/README.md
+++ b/packages/plugin-vue/README.md
@@ -46,7 +46,7 @@ export interface Options {
   customElement?: boolean | string | RegExp | (string | RegExp)[]
 
   /**
-   * Enable Vue reactivity transform (deprecated).
+   * Enable Vue reactivity transform (experimental).
    * https://vuejs.org/guide/extras/reactivity-transform.html
    * - `true`: transform will be enabled for all vue,js(x),ts(x) files except
    *           those inside node_modules
@@ -54,6 +54,7 @@ export interface Options {
    *                      node_modules, so specify directories if necessary)
    * - `false`: disable in all cases
    *
+   * @experimental
    * @deprecated
    * @default false
    */

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -100,8 +100,6 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
     exclude,
     customElement = /\.ce\.vue$/,
     reactivityTransform = false,
-    defineModel = false,
-    propsDestructure = false,
   } = rawOptions
 
   const filter = createFilter(include, exclude)
@@ -126,8 +124,6 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
     exclude,
     customElement,
     reactivityTransform,
-    defineModel,
-    propsDestructure,
     root: process.cwd(),
     sourceMap: true,
     cssDevSourcemap: false,

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -66,6 +66,20 @@ export interface Options {
   reactivityTransform?: boolean | string | RegExp | (string | RegExp)[]
 
   /**
+   * Enable `defineModel` macro (experimental).
+   * https://github.com/vuejs/rfcs/discussions/503
+   * @default false
+   */
+  defineModel?: boolean
+
+  /**
+   * Enable reactive props destructure (experimental).
+   * https://github.com/vuejs/rfcs/discussions/502
+   * @default false
+   */
+  propsDestructure?: boolean
+
+  /**
    * Use custom compiler-sfc instance. Can be used to force a specific version.
    */
   compiler?: typeof _compiler
@@ -86,6 +100,8 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
     exclude,
     customElement = /\.ce\.vue$/,
     reactivityTransform = false,
+    defineModel = false,
+    propsDestructure = false,
   } = rawOptions
 
   const filter = createFilter(include, exclude)
@@ -110,6 +126,8 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
     exclude,
     customElement,
     reactivityTransform,
+    defineModel,
+    propsDestructure,
     root: process.cwd(),
     sourceMap: true,
     cssDevSourcemap: false,

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -53,7 +53,7 @@ export interface Options {
   customElement?: boolean | string | RegExp | (string | RegExp)[]
 
   /**
-   * Enable Vue reactivity transform (deprecated).
+   * Enable Vue reactivity transform (experimental).
    * https://vuejs.org/guide/extras/reactivity-transform.html
    * - `true`: transform will be enabled for all vue,js(x),ts(x) files except
    *           those inside node_modules
@@ -61,6 +61,7 @@ export interface Options {
    *                      node_modules, so specify directories if necessary)
    * - `false`: disable in all cases
    *
+   * @experimental
    * @deprecated
    * @default false
    */

--- a/packages/plugin-vue/src/script.ts
+++ b/packages/plugin-vue/src/script.ts
@@ -67,6 +67,8 @@ export function resolveScript(
     isProd: options.isProduction,
     inlineTemplate: isUseInlineTemplate(descriptor, !options.devServer),
     reactivityTransform: options.reactivityTransform !== false,
+    defineModel: options.defineModel,
+    propsDestructure: options.propsDestructure,
     templateOptions: resolveTemplateCompilerOptions(descriptor, options, ssr),
     sourceMap: options.sourceMap,
     genDefaultAs: canInlineMain(descriptor, options)

--- a/playground/vue/Main.vue
+++ b/playground/vue/Main.vue
@@ -24,6 +24,7 @@
     <AsyncComponent />
   </Suspense>
   <ReactivityTransform :foo="time" />
+  <PropDestructure :bar="time" />
   <SetupImportTemplate />
   <WorkerTest />
   <Url />
@@ -45,6 +46,7 @@ import ScanDep from './ScanDep.vue'
 import TsImport from './TsImport.vue'
 import AsyncComponent from './AsyncComponent.vue'
 import ReactivityTransform from './ReactivityTransform.vue'
+import PropDestructure from './PropDestructure.vue'
 import SetupImportTemplate from './setup-import-template/SetupImportTemplate.vue'
 import WorkerTest from './worker.vue'
 import { ref } from 'vue'

--- a/playground/vue/PropDestructure.vue
+++ b/playground/vue/PropDestructure.vue
@@ -1,0 +1,8 @@
+<script setup>
+const { bar: baz } = defineProps(['foo'])
+</script>
+
+<template>
+  <h2>Prop Destructure</h2>
+  <p>Prop bar: {{ baz }}</p>
+</template>

--- a/playground/vue/vite.config.ts
+++ b/playground/vue/vite.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
   plugins: [
     vuePlugin({
       reactivityTransform: true,
+      defineModel: true,
+      propDestructure: true,
     }),
     splitVendorChunkPlugin(),
     vueI18nPlugin,

--- a/playground/vue/vite.config.ts
+++ b/playground/vue/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     vuePlugin({
       reactivityTransform: true,
       defineModel: true,
-      propDestructure: true,
+      propsDestructure: true,
     }),
     splitVendorChunkPlugin(),
     vueI18nPlugin,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add types for  `defineModel` macro and reactive props destructure.

close #161

### Additional context

https://blog.vuejs.org/posts/vue-3-3

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite-plugin-vue/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

(add test cases soon)