### PR TITLE
fix: missing typescript declaration for globalTypeFiles

### DIFF
--- a/packages/plugin-vue/README.md
+++ b/packages/plugin-vue/README.md
@@ -23,7 +23,18 @@ export interface Options {
   isProduction?: boolean
 
   // options to pass on to vue/compiler-sfc
-  script?: Partial<Pick<SFCScriptCompileOptions, 'babelParserPlugins'>>
+  script?: Partial<
+    Pick<
+      SFCScriptCompileOptions,
+      | 'babelParserPlugins'
+      | 'globalTypeFiles'
+      | 'defineModel'
+      | 'propsDestructure'
+      | 'fs'
+      | 'reactivityTransform'
+    >
+  >
+
   template?: Partial<
     Pick<
       SFCTemplateCompileOptions,

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -34,6 +34,7 @@ export interface Options {
     Pick<
       SFCScriptCompileOptions,
       | 'babelParserPlugins'
+      | 'globalTypeFiles'
       | 'defineModel'
       | 'propsDestructure'
       | 'fs'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

https://github.com/vuejs/core/commit/4e028b966991937c83fb2529973fd3d41080bb61
Added the possibility to define `globalTypeFiles` for the `vue/compiler-sfc`. However, this plugin is still missing the new type.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

I am relatively new to the vue ecosystem. So I hope I added it to all the necessary places..

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Readme Update
- [x] Typescript Declarations Update
