### PR TITLE
feat: Add special query to load customElements

### DIFF
--- a/packages/plugin-vue/README.md
+++ b/packages/plugin-vue/README.md
@@ -182,6 +182,18 @@ The `customElement` plugin option can be used to configure the behavior:
 - `{ customElement: true }` will import all `*.vue` files in custom element mode.
 - Use a string or regex pattern to change how files should be loaded as Custom Elements (this check is applied after `include` and `exclude` matches).
 
+### Special Query
+
+Special query can be used to load the Vue component as a custom element without changing the file extension or global configuration:
+
+```js
+import { defineCustomElement } from 'vue'
+import Example from './Example.vue?customElement'
+
+// register
+customElements.define('my-example', defineCustomElement(Example))
+```
+
 ## License
 
 MIT

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -257,7 +257,7 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
           options,
           this,
           ssr,
-          customElementFilter(filename),
+          customElementFilter(filename) || 'customElement' in query,
         )
       } else {
         // sub block request


### PR DESCRIPTION
### Description: Special Query `customElement`

closes: #214 

Special query can be used to load a Vue component as a custom element without changing the file extension or global configuration:

```js
import { defineCustomElement } from 'vue'
import Example from './Example.vue?customElement'

// register
customElements.define('my-example', defineCustomElement(Example))

Special query can be used to load the Vue component as a custom element without changing the file extension or global configuration:

```js
import { defineCustomElement } from 'vue'
import Example from './Example.vue?customElement'

// register
customElements.define('my-example', defineCustomElement(Example))

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite-plugin-vue/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
