### PR TITLE
fix(plugin-vue): deprecate inline main (fix #31)

### DIFF
--- a/packages/plugin-vue/src/script.ts
+++ b/packages/plugin-vue/src/script.ts
@@ -69,9 +69,6 @@ export function resolveScript(
     reactivityTransform: options.reactivityTransform !== false,
     templateOptions: resolveTemplateCompilerOptions(descriptor, options, ssr),
     sourceMap: options.sourceMap,
-    genDefaultAs: canInlineMain(descriptor, options)
-      ? scriptIdentifier
-      : undefined,
   })
 
   if (!options.isProduction && resolved?.deps) {
@@ -93,23 +90,4 @@ export function resolveScript(
 
   cacheToUse.set(descriptor, resolved)
   return resolved
-}
-
-// If the script is js/ts and has no external src, it can be directly placed
-// in the main module. Skip for build
-export function canInlineMain(
-  descriptor: SFCDescriptor,
-  options: ResolvedOptions,
-): boolean {
-  if (descriptor.script?.src || descriptor.scriptSetup?.src) {
-    return false
-  }
-  const lang = descriptor.script?.lang || descriptor.scriptSetup?.lang
-  if (!lang) {
-    return true
-  }
-  if (lang === 'ts' && options.devServer) {
-    return true
-  }
-  return false
 }


### PR DESCRIPTION
### Description

`vite-plugin-vue` should deprecate **inline main**, because `.vue` file can't be processed as `js/ts`. 

fix:  #31, [vite#13756](https://github.com/vitejs/vite/issues/13756)

### Additional context

When using `vite dev`, `lang="js"` or `lang="ts"` will be skip build, 

Live demo: [stackblitz](https://stackblitz.com/edit/vitejs-vite-2zce3s?file=src%2FApp.vue)

`lang="js"` or `lang="ts"` will as **inline main**, skip js/ts build. Because its extname is `.vue`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite-plugin-vue/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
