### PR TITLE
fix: make it work when a default lang was specified

### DIFF
--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -264,7 +264,7 @@ async function genTemplateCode(
   // If the template is not using pre-processor AND is not using external src,
   // compile and inline it directly in the main module. When served in vite this
   // saves an extra request per SFC which can improve load performance.
-  if (!template.lang && !template.src) {
+  if ((!template.lang || template.lang === 'html') && !template.src) {
     return transformTemplateInMain(
       template.content,
       descriptor,

--- a/packages/plugin-vue/src/script.ts
+++ b/packages/plugin-vue/src/script.ts
@@ -105,7 +105,7 @@ export function canInlineMain(
     return false
   }
   const lang = descriptor.script?.lang || descriptor.scriptSetup?.lang
-  if (!lang) {
+  if (!lang || lang === 'js') {
     return true
   }
   if (lang === 'ts' && options.devServer) {

--- a/packages/plugin-vue/src/template.ts
+++ b/packages/plugin-vue/src/template.ts
@@ -176,7 +176,7 @@ export function resolveTemplateCompilerOptions(
     ssr,
     ssrCssVars: cssVars,
     transformAssetUrls,
-    preprocessLang: block.lang,
+    preprocessLang: block.lang === 'html' ? undefined : block.lang,
     preprocessOptions,
     compilerOptions: {
       ...options.template?.compilerOptions,

--- a/playground/vue/DefaultLangs.vue
+++ b/playground/vue/DefaultLangs.vue
@@ -1,0 +1,16 @@
+<template lang="html">
+  <h2>default langs</h2>
+  <div>
+    default lang: <span class="default-langs">{{ foo }}</span>
+  </div>
+</template>
+
+<script setup lang="js">
+const foo = 'foo'
+</script>
+
+<style scoped lang="css">
+.default-langs {
+  color: blue;
+}
+</style>

--- a/playground/vue/Main.vue
+++ b/playground/vue/Main.vue
@@ -29,6 +29,7 @@
   <WorkerTest />
   <Url />
   <TsGeneric msg="hello" />
+  <DefaultLangs />
 </template>
 
 <script setup lang="ts">
@@ -52,6 +53,7 @@ import WorkerTest from './worker.vue'
 import { ref } from 'vue'
 import Url from './Url.vue'
 import TypeProps from './TypeProps.vue'
+import DefaultLangs from './DefaultLangs.vue'
 
 const TsGeneric = defineAsyncComponent(() => import('./TsGeneric.vue'))
 

--- a/playground/vue/__tests__/vue.spec.ts
+++ b/playground/vue/__tests__/vue.spec.ts
@@ -337,3 +337,10 @@ describe('macro imported types', () => {
 test('TS with generics', async () => {
   expect(await page.textContent('.generic')).toMatch('hello')
 })
+
+describe('default langs', () => {
+  test('should work', async () => {
+    expect(await page.textContent('.default-langs')).toBe('foo')
+    expect(await getColor('.default-langs')).toBe('blue')
+  })
+})

--- a/playground/vue/tsconfig.json
+++ b/playground/vue/tsconfig.json
@@ -3,6 +3,7 @@
     // esbuild transpile should ignore this
     "target": "ES5",
     "jsx": "preserve",
+    "allowJs": true,
     "paths": {
       "~utils": ["../test-utils.ts"],
       "~types": ["./types-aliased.d.ts"]


### PR DESCRIPTION
### Description

Resolved merge conflicts for https://github.com/vitejs/vite-plugin-vue/pull/65.

---

```vue
<template lang="html">
  <div>foo</div>
</script>
```

and

```
<script setup lang="js">
const foo = 'foo'
</script>
```

didn't work.
This PR fixes these.

requires https://github.com/vuejs/core/issues/7388
fixes https://github.com/vitejs/vite-plugin-vue/issues/17

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite-plugin-vue/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
