### PR TITLE
fix(plugin-vue): distinguish HMR and transform descriptor

### DIFF
--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -9,6 +9,7 @@ import { addMapping, fromMap, toEncodedMap } from '@jridgewell/gen-mapping'
 import { normalizePath, transformWithEsbuild } from 'vite'
 import {
   createDescriptor,
+  getDescriptor,
   getPrevDescriptor,
   setSrcDescriptor,
 } from './utils/descriptorCache'
@@ -35,9 +36,11 @@ export async function transformMain(
 ) {
   const { devServer, isProduction, devToolsEnabled } = options
 
-  // prev descriptor is only set and used for hmr
   const prevDescriptor = getPrevDescriptor(filename)
   const { descriptor, errors } = createDescriptor(filename, code, options)
+
+  // set descriptor for HMR if it's not set yet
+  getDescriptor(filename, options, true, true)
 
   if (errors.length) {
     errors.forEach((error) =>

--- a/packages/plugin-vue/src/utils/descriptorCache.ts
+++ b/packages/plugin-vue/src/utils/descriptorCache.ts
@@ -12,12 +12,14 @@ export interface SFCParseResult {
 }
 
 export const cache = new Map<string, SFCDescriptor>()
+export const hmrCache = new Map<string, SFCDescriptor>()
 const prevCache = new Map<string, SFCDescriptor | undefined>()
 
 export function createDescriptor(
   filename: string,
   source: string,
   { root, isProduction, sourceMap, compiler }: ResolvedOptions,
+  hmr = false,
 ): SFCParseResult {
   const { descriptor, errors } = compiler.parse(source, {
     filename,
@@ -28,8 +30,7 @@ export function createDescriptor(
   // project (relative to root) and on different systems.
   const normalizedPath = slash(path.normalize(path.relative(root, filename)))
   descriptor.id = getHash(normalizedPath + (isProduction ? source : ''))
-
-  cache.set(filename, descriptor)
+  ;(hmr ? hmrCache : cache).set(filename, descriptor)
   return { descriptor, errors }
 }
 
@@ -37,26 +38,31 @@ export function getPrevDescriptor(filename: string): SFCDescriptor | undefined {
   return prevCache.get(filename)
 }
 
-export function setPrevDescriptor(
-  filename: string,
-  entry: SFCDescriptor,
-): void {
-  prevCache.set(filename, entry)
+export function invalidateDescriptor(filename: string, hmr = false): void {
+  const _cache = hmr ? hmrCache : cache
+  const prev = _cache.get(filename)
+  _cache.delete(filename)
+  if (prev) {
+    prevCache.set(filename, prev)
+  }
 }
 
 export function getDescriptor(
   filename: string,
   options: ResolvedOptions,
   createIfNotFound = true,
+  hmr = false,
 ): SFCDescriptor | undefined {
-  if (cache.has(filename)) {
-    return cache.get(filename)!
+  const _cache = hmr ? hmrCache : cache
+  if (_cache.has(filename)) {
+    return _cache.get(filename)!
   }
   if (createIfNotFound) {
     const { descriptor, errors } = createDescriptor(
       filename,
       fs.readFileSync(filename, 'utf-8'),
       options,
+      hmr,
     )
     if (errors.length) {
       throw errors[0]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Distinguish HMR and transform descriptor

Transform descriptors are not the same as HMR descriptors. Transform one will be transformed by Vite plugin, but HMR one is read from filesystem directly (without transform)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite-plugin-vue/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
