### PR TITLE
chore: set ssr manifest path

### DIFF
--- a/playground/ssr-vue/__tests__/serve.ts
+++ b/playground/ssr-vue/__tests__/serve.ts
@@ -22,7 +22,7 @@ export async function serve(): Promise<{ close(): Promise<void> }> {
       build: {
         target: 'esnext',
         minify: false,
-        ssrManifest: true,
+        ssrManifest: '.vite/ssr-manifest.json',
         outDir: 'dist/client',
       },
     })

--- a/playground/ssr-vue/__tests__/ssr-vue.spec.ts
+++ b/playground/ssr-vue/__tests__/ssr-vue.spec.ts
@@ -206,7 +206,7 @@ test.runIf(isBuild)('dynamic css file should be preloaded', async () => {
     await import(
       resolve(
         process.cwd(),
-        './playground-temp/ssr-vue/dist/client/ssr-manifest.json',
+        './playground-temp/ssr-vue/dist/client/.vite/ssr-manifest.json',
       )
     )
   ).default

--- a/playground/ssr-vue/package.json
+++ b/playground/ssr-vue/package.json
@@ -7,10 +7,10 @@
     "dev": "node server",
     "build": "npm run build:client && npm run build:server",
     "build:noExternal": "npm run build:client && npm run build:server:noExternal",
-    "build:client": "vite build --ssrManifest --outDir dist/client",
+    "build:client": "vite build --ssrManifest .vite/ssr-manifest.json --outDir dist/client",
     "build:server": "vite build --ssr src/entry-server.js --outDir dist/server",
     "build:server:noExternal": "vite build --config vite.config.noexternal.js --ssr src/entry-server.js --outDir dist/server",
-    "generate": "vite build --ssrManifest --outDir dist/static && npm run build:server && node prerender",
+    "generate": "vite build --ssrManifest .vite/ssr-manifest.json --outDir dist/static && npm run build:server && node prerender",
     "serve": "NODE_ENV=production node server",
     "debug": "node --inspect-brk server"
   },

--- a/playground/ssr-vue/prerender.js
+++ b/playground/ssr-vue/prerender.js
@@ -10,7 +10,7 @@ const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 const toAbsolute = (p) => path.resolve(__dirname, p)
 
 const manifest = JSON.parse(
-  fs.readFileSync(toAbsolute('dist/static/ssr-manifest.json'), 'utf-8'),
+  fs.readFileSync(toAbsolute('dist/static/.vite/ssr-manifest.json'), 'utf-8'),
 )
 const template = fs.readFileSync(toAbsolute('dist/static/index.html'), 'utf-8')
 const { render } = await import('./dist/server/entry-server.js')
@@ -37,6 +37,6 @@ const routesToPrerender = fs
     console.log('pre-rendered:', filePath)
   }
 
-  // done, delete ssr manifest
-  fs.unlinkSync(toAbsolute('dist/static/ssr-manifest.json'))
+  // done, delete .vite directory including ssr manifest
+  fs.rmSync(toAbsolute('dist/static/.vite'), { recursive: true })
 })()

--- a/playground/ssr-vue/server.js
+++ b/playground/ssr-vue/server.js
@@ -20,7 +20,10 @@ export async function createServer(
 
   const manifest = isProd
     ? JSON.parse(
-        fs.readFileSync(resolve('dist/client/ssr-manifest.json'), 'utf-8'),
+        fs.readFileSync(
+          resolve('dist/client/.vite/ssr-manifest.json'),
+          'utf-8',
+        ),
       )
     : {}
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Set SSR manifest path so that the test passes after https://github.com/vitejs/vite/pull/14230 is merged.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
