### PR TITLE
fix(plugin-vue): hmr parse error when other plugins modify data

### DIFF
--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -149,8 +149,9 @@ export async function handleHotUpdate(
   }
   if (updateType.length) {
     // invalidate the descriptor cache so that the next transform will
-    // re-analyze the file and pick up the changes.
     invalidateDescriptor(file)
+    // re-analyze the file and pick up the changes.
+    createDescriptor(file, content, options)
     debug(`[vue:update(${updateType.join('&')})] ${file}`)
   }
   return [...affectedModules].filter(Boolean) as ModuleNode[]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix an error when HMR gets inconsistent data.  

An example that reproduces the error, using unocss's `vue-scoped` schema, a template change to the class in the .vue file will result in a parsing error due to incorrect data being read.

Link: https://stackblitz.com/edit/unocss-unocss-zcq2jt?file=src%2FApp.vue

---

Currently the old cache is being deleted in the `handleHotUpdate` hook, so there may be a case where the correct data is not available via `getDescriptor` in the `transform` hook.


In this PR, the old cache is emptied and then cached again based on the latest data.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
