### PR TITLE
chore: use `import type` for type only file import

### DIFF
--- a/playground/ssr-vue/src/components/ImportType.vue
+++ b/playground/ssr-vue/src/components/ImportType.vue
@@ -3,6 +3,9 @@
 </template>
 
 <script setup lang="ts">
-import { Foo } from '@vitejs/test-dep-import-type/deep'
+// FIXME: @vitejs/test-dep-import-type/deep is a type only file
+//        So currently it needs to be imported with `import type`
+//        https://github.com/vitejs/vite-plugin-vue/issues/24
+import type { Foo } from '@vitejs/test-dep-import-type/deep'
 const msg: Foo = {}
 </script>


### PR DESCRIPTION
### Description
This PR fixes the error in ecosystem-ci: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/6401781367/job/17379560146#step:8:460

Vite 5's scanner now crawls dynamic imports with variables.
This line was not working since https://github.com/vitejs/vite/pull/5850 was merged but no error happened because the scanner wasn't crawling this file.
See https://github.com/vitejs/vite/pull/14533 for more details.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
