### PR TITLE
test: update config to support vite 5

### DIFF
--- a/playground/vue/vite.config.ts
+++ b/playground/vue/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
   build: {
     // to make tests faster
     minify: false,
+    assetsInlineLimit: 100, // keep SVG as assets URL
     rollupOptions: {
       output: {
         // Test splitVendorChunkPlugin composition


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Decrease the `assetsInlineLimit` for now since SVGs in Vite 5 are now inlined which breaks:

https://github.com/vitejs/vite-plugin-vue/blob/298d419bbb2c2402a4b2745343abd09c5f3e5814/playground/vue/__tests__/vue.spec.ts#L162

This fix should work in both Vite 4 and 5.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
