### PR TITLE
chore: update peerDependencies to support Vite 5

### DIFF
--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue#readme",
   "peerDependencies": {
-    "vite": "^4.0.0",
+    "vite": "^4.0.0 || ^5.0.0",
     "vue": "^3.2.25"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

Vite 5 will be released today.

A new major could also be done in case we want to drop Node 16 already, but we can already support Vite 5 with a patch.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other