### PR TITLE
fix: hmr got error by transformSFC to inject code (fix #301)

### DIFF
--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -31,7 +31,7 @@ export async function handleHotUpdate(
   { file, modules, read }: HmrContext,
   options: ResolvedOptions,
 ): Promise<ModuleNode[] | void> {
-  const prevDescriptor = getDescriptor(file, options, false, true)
+  const prevDescriptor = await getDescriptor(file, options, false, true)
   if (!prevDescriptor) {
     // file hasn't been requested yet (e.g. async component)
     return

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -42,7 +42,7 @@ export async function transformMain(
 
   if (fs.existsSync(filename)) {
     // populate descriptor cache for HMR if it's not set yet
-    getDescriptor(
+    await getDescriptor(
       filename,
       options,
       true,

--- a/packages/plugin-vue/src/utils/descriptorCache.ts
+++ b/packages/plugin-vue/src/utils/descriptorCache.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { createHash } from 'node:crypto'
 import slash from 'slash'
+import type { Plugin } from 'vite'
 import type { CompilerError, SFCDescriptor } from 'vue/compiler-sfc'
 import type { ResolvedOptions, VueQuery } from '..'
 
@@ -51,13 +52,13 @@ export function invalidateDescriptor(filename: string, hmr = false): void {
   }
 }
 
-export function getDescriptor(
+export async function getDescriptor(
   filename: string,
   options: ResolvedOptions,
   createIfNotFound = true,
   hmr = false,
   code?: string,
-): SFCDescriptor | undefined {
+): Promise<SFCDescriptor | undefined> {
   const _cache = hmr ? hmrCache : cache
   if (_cache.has(filename)) {
     return _cache.get(filename)!
@@ -65,7 +66,7 @@ export function getDescriptor(
   if (createIfNotFound) {
     const { descriptor, errors } = createDescriptor(
       filename,
-      code ?? fs.readFileSync(filename, 'utf-8'),
+      code ?? await options.readCode(filename),
       options,
       hmr,
     )
@@ -117,6 +118,25 @@ export function setSrcDescriptor(
     return
   }
   cache.set(filename, entry)
+}
+
+type TransformCode = (filename: string, code: string) => Promise<string | null>
+
+export function getReadCode(plugins: readonly Plugin<{ transformCode?: TransformCode }>[]): (filename: string) => Promise<string> {
+  const transformCodeFns = (plugins || []).reduce<TransformCode[]>((fns, plugin) => {
+    if (plugin.name.endsWith(':api') && typeof plugin.api?.transformCode === 'function') {
+      fns.push(plugin.api.transformCode)
+    }
+    return fns
+  }, [])
+
+  return async (filename: string) => {
+    let code = fs.readFileSync(filename, 'utf-8')
+    for (const transformCode of transformCodeFns) {
+      code = (await transformCode(filename, code)) || code
+    }
+    return code
+  }
 }
 
 function getHash(text: string): string {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

FIXED: #301 

Some vite plugins like `unocss:vue-scoped` needs to rewrite `hmrContext.read` to inject their special code into SFC when hmr.

`vite-plugin-vue` uses `fs.readFileSync` to get the raw code, but the raw code doesn't have injected code by other plugins.

This PR allows `vite-plugin-vue` to get `transformCode` api from other plugins, and then replace `fs.readFileSync` with `readCode` function.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

- hmr error reproduction: https://stackblitz.com/edit/vitejs-vite-28qyca?file=src%2FApp.vue
  -  Wait to start and change class `text-blue` to `text-red`
- playground for this PR: https://stackblitz.com/edit/vitejs-vite-6tuitn?file=src%2FApp.vue
  - u can run it locally
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
