### PR TITLE
fix(plugin-vue): allow disabling transformAssetUrls

### DIFF
--- a/packages/plugin-vue/src/template.ts
+++ b/packages/plugin-vue/src/template.ts
@@ -131,7 +131,9 @@ export function resolveTemplateCompilerOptions(
   let transformAssetUrls = options.template?.transformAssetUrls
   // compiler-sfc should export `AssetURLOptions`
   let assetUrlOptions //: AssetURLOptions | undefined
-  if (options.devServer) {
+  if (transformAssetUrls === false) {
+    // if explicitly disabled, let assetUrlOptions be undefined
+  } else if (options.devServer) {
     // during dev, inject vite base so that compiler-sfc can transform
     // relative paths directly to absolute paths without incurring an extra import
     // request
@@ -145,7 +147,7 @@ export function resolveTemplateCompilerOptions(
         includeAbsolute: !!devBase,
       }
     }
-  } else if (transformAssetUrls !== false) {
+  } else {
     // build: force all asset urls into import requests so that they go through
     // the assets plugin for asset registration
     assetUrlOptions = {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In Astro, it has its own image handling that returns image imports as an object, rather than a string. This would break when Vue automatically transform asset reference to imports.

However, when we try to disable with `transformAssetUrls: false`, it didn't work due to the logic flow, and always enabled it anyways. This PR fixes it.

There is a workaround today (https://github.com/withastro/astro/issues/9328#issuecomment-1842752441), but I figured it's better to improve this anyway.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
