### PR TITLE
fix(plugin-vue-jsx): replace export default defineComponent with babel (fix #345)

### DIFF
--- a/packages/plugin-vue-jsx/src/index.ts
+++ b/packages/plugin-vue-jsx/src/index.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import path from 'node:path'
-import type { types } from '@babel/core'
+import { types } from '@babel/core'
 import * as babel from '@babel/core'
 import jsx from '@vue/babel-plugin-jsx'
 import { createFilter, normalizePath } from 'vite'
@@ -112,6 +112,36 @@ function vueJsxPlugin(options: Options = {}): Plugin {
               },
             }
           })
+        } else {
+          plugins.push(() => {
+            return {
+              visitor: {
+                ExportDefaultDeclaration: {
+                  enter(_path: babel.NodePath<types.ExportDefaultDeclaration>) {
+                    if (isDefineComponentCall(_path.node.declaration)) {
+                      const declaration = _path.node
+                        .declaration as CallExpression
+                      const nodesPath = _path.replaceWithMultiple([
+                        types.variableDeclaration('const', [
+                          types.variableDeclarator(
+                            types.identifier('__default__'),
+                            types.callExpression(
+                              declaration.callee,
+                              declaration.arguments,
+                            ),
+                          ),
+                        ]),
+                        types.exportDefaultDeclaration(
+                          types.identifier('__default__'),
+                        ),
+                      ])
+                      _path.scope.registerDeclaration(nodesPath[0])
+                    }
+                  },
+                },
+              },
+            }
+          })
         }
 
         const result = babel.transformSync(code, {
@@ -140,7 +170,6 @@ function vueJsxPlugin(options: Options = {}): Plugin {
         // check for hmr injection
         const declaredComponents: string[] = []
         const hotComponents: HotComponent[] = []
-        let hasDefault = false
 
         for (const node of result.ast!.program.body) {
           if (node.type === 'VariableDeclaration') {
@@ -195,7 +224,6 @@ function vueJsxPlugin(options: Options = {}): Plugin {
                 })
               }
             } else if (isDefineComponentCall(node.declaration)) {
-              hasDefault = true
               hotComponents.push({
                 local: '__default__',
                 exported: 'default',
@@ -206,14 +234,6 @@ function vueJsxPlugin(options: Options = {}): Plugin {
         }
 
         if (hotComponents.length) {
-          if (hasDefault && (needHmr || ssr)) {
-            result.code =
-              result.code!.replace(
-                /export default defineComponent/g,
-                `const __default__ = defineComponent`,
-              ) + `\nexport default __default__`
-          }
-
           if (needHmr && !ssr && !/\?vue&type=script/.test(id)) {
             let code = result.code
             let callbackCode = ``

--- a/playground/vue-jsx/ExportDefault.jsx
+++ b/playground/vue-jsx/ExportDefault.jsx
@@ -1,0 +1,7 @@
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  render() {
+    return <span class="export-default">export default defineComponent</span>
+  },
+})

--- a/playground/vue-jsx/__tests__/vue-jsx.spec.ts
+++ b/playground/vue-jsx/__tests__/vue-jsx.spec.ts
@@ -11,6 +11,9 @@ test('should render', async () => {
   expect(await page.textContent('.jsx-with-query')).toMatch('6')
   expect(await page.textContent('.other-ext')).toMatch('Other Ext')
   expect(await page.textContent('.ts-import')).toMatch('success')
+  expect(await page.textContent('.export-default')).toMatch(
+    'export default defineComponent',
+  )
 })
 
 test('should update', async () => {

--- a/playground/vue-jsx/main.jsx
+++ b/playground/vue-jsx/main.jsx
@@ -8,6 +8,7 @@ import JsxSetupSyntax from './setup-syntax-jsx.vue'
 // eslint-disable-next-line
 import JsxWithQuery from './Query.jsx?query=true'
 import TsImport from './TsImport.vue'
+import ExportDefault from './ExportDefault'
 
 function App() {
   return (
@@ -22,6 +23,7 @@ function App() {
       <JsxSetupSyntax />
       <JsxWithQuery />
       <TsImport />
+      <ExportDefault />
     </>
   )
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

```JavaScript
if (hasDefault && (needHmr || ssr)) {
  result.code =
    result.code!.replace(
      /export default defineComponent/g,
      `const __default__ = defineComponent`,
    ) + `\nexport default __default__`
}
```
The code above will compile `const str = 'export default defineComponent'` unexpectedly in the development environment

We can achieve the same task with babel

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

issue #345 

reproduction https://stackblitz.com/edit/vitejs-vite-rgsvev?file=src%2FApp.tsx

resolution https://stackblitz.com/~/github.com/OMGVecchio/vite-plugin-vue?file=demo/ExportDefault.jsx

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
