### PR TITLE
fix(plugin-vue): allow disabling hmr template caching (#8)

### DIFF
--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -110,6 +110,7 @@ export interface ResolvedOptions extends Options {
   cssDevSourcemap: boolean
   devServer?: ViteDevServer
   devToolsEnabled?: boolean
+  disableTemplateCache?: boolean
 }
 
 export interface Api {

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -149,7 +149,7 @@ export async function transformMain(
         `__VUE_HMR_RUNTIME__.createRecord(_sfc_main.__hmrId, _sfc_main)`,
     )
     // check if the template is the only thing that changed
-    if (prevDescriptor && isOnlyTemplateChanged(prevDescriptor, descriptor)) {
+    if (!options.disableTemplateCache && prevDescriptor && isOnlyTemplateChanged(prevDescriptor, descriptor)) {
       output.push(`export const _rerender_only = true`)
     }
     output.push(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes HMR not working as expected when Vue script and template are in separate files (as described in #8) by allowing to disable template caching in HMR through plugin options.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

-----
<a href="https://stackblitz.com/~/github.com/EmilieOLIVIE/vite-plugin-vue/tree/main"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/EmilieOLIVIE/vite-plugin-vue/tree/main)._