### PR TITLE
feat: added option dataAttributeSalt to saltify data-attributes

### DIFF
--- a/packages/plugin-vue/README.md
+++ b/packages/plugin-vue/README.md
@@ -58,6 +58,10 @@ export interface Options {
      * - **default:** `false`
      */
     prodHydrationMismatchDetails?: boolean
+    /**
+     * Custom value to add to data-attribute for components with `scoped` styles
+     */
+    dataAttributeSalt?: string
   }
 
   // `script`, `template` and `style` are lower-level compiler options

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -138,6 +138,11 @@ export interface Options {
      * - **default:** `false`
      */
     prodHydrationMismatchDetails?: boolean
+
+    /**
+     * Custom value to add to data-attribute for components with `scoped` styles
+     */
+    dataAttributeSalt?: string
   }
 
   /**

--- a/packages/plugin-vue/src/utils/descriptorCache.ts
+++ b/packages/plugin-vue/src/utils/descriptorCache.ts
@@ -22,7 +22,14 @@ const prevCache = new Map<string, SFCDescriptor | undefined>()
 export function createDescriptor(
   filename: string,
   source: string,
-  { root, isProduction, sourceMap, compiler, template }: ResolvedOptions,
+  {
+    root,
+    isProduction,
+    sourceMap,
+    compiler,
+    template,
+    features,
+  }: ResolvedOptions,
   hmr = false,
 ): SFCParseResult {
   const { descriptor, errors } = compiler.parse(source, {
@@ -34,7 +41,8 @@ export function createDescriptor(
   // ensure the path is normalized in a way that is consistent inside
   // project (relative to root) and on different systems.
   const normalizedPath = normalizePath(path.relative(root, filename))
-  descriptor.id = getHash(normalizedPath + (isProduction ? source : ''))
+  const hash = getHash(normalizedPath + (isProduction ? source : ''))
+  descriptor.id = `${hash}${features?.dataAttributeSalt ?? ''}`
   ;(hmr ? hmrCache : cache).set(filename, descriptor)
   return { descriptor, errors }
 }


### PR DESCRIPTION
### Description

If you are dealing with MFE and own ui-kit, you need the ability to use different version of ui-kit on different MFE's.
But on our project we encountered a problem: styles from diffrent version of ui-kit overwrite each other.


### Additional context

We tried to use attribute `scoped` on styles, but it didn't help. This is because data-attributes are based on a hash of the component code and if the styles are in a separate file the hash doesn't change.

The `dataAttributeSalt` option helps to provide a "salt" to a data-attribute which can contain any value you want (for example random value or version number).

Therefore styles become unique throught the MFE even if they use different versions of ui-kit with different styles.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [X] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
