### PR TITLE
fix: skip checking private properties of typeParameters

### DIFF
--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -259,7 +259,7 @@ function isEqualAst(prev?: t.Statement[], next?: t.Statement[]): boolean {
     return prev === next
   }
 
-  // deep equal, but ignore start/end/loc/range/leadingComments/trailingComments/innerComments
+  // deep equal, but ignore start/end/loc/range/leadingComments/trailingComments/innerComments/typeParameters
   if (prev.length !== next.length) {
     return false
   }

--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -276,6 +276,8 @@ function isEqualAst(prev?: t.Statement[], next?: t.Statement[]): boolean {
         'leadingComments',
         'trailingComments',
         'innerComments',
+         // https://github.com/vuejs/core/issues/11923
+         // avoid comparing typeParameters, as it may be imported from 3rd lib and complex to compare
         'typeParameters',
       ])
     ) {

--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -276,6 +276,7 @@ function isEqualAst(prev?: t.Statement[], next?: t.Statement[]): boolean {
         'leadingComments',
         'trailingComments',
         'innerComments',
+        'typeParameters',
       ])
     ) {
       return false

--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -259,7 +259,6 @@ function isEqualAst(prev?: t.Statement[], next?: t.Statement[]): boolean {
     return prev === next
   }
 
-  // deep equal, but ignore start/end/loc/range/leadingComments/trailingComments/innerComments/typeParameters
   if (prev.length !== next.length) {
     return false
   }
@@ -268,6 +267,7 @@ function isEqualAst(prev?: t.Statement[], next?: t.Statement[]): boolean {
     const prevNode = prev[i]
     const nextNode = next[i]
     if (
+      // deep equal, but ignore start/end/loc/range/leadingComments/trailingComments/innerComments
       !deepEqual(prevNode, nextNode, [
         'start',
         'end',
@@ -277,8 +277,11 @@ function isEqualAst(prev?: t.Statement[], next?: t.Statement[]): boolean {
         'trailingComments',
         'innerComments',
          // https://github.com/vuejs/core/issues/11923
-         // avoid comparing typeParameters, as it may be imported from 3rd lib and complex to compare
-        'typeParameters',
+         // avoid comparing the following properties of typeParameters
+         // as it may be imported from 3rd lib and complex to compare
+        '_ownerScope',
+        '_resolvedReference',
+        '_resolvedElements'
       ])
     ) {
       return false


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vuejs/core/issues/11923
The types imported from third-party libraries can be quite complex, and comparing them for equality is time-consuming.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
