### PR TITLE
fix(plugin-vue): allow overwrite esbuild config

### DIFF
--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -249,8 +249,11 @@ export async function transformMain(
       resolvedCode,
       filename,
       {
-        loader: 'ts',
         target: 'esnext',
+        // #430 Support decorators in .vue file. https://github.com/vitejs/vite-plugin-vue/issues/430
+        // target can be overridden by esbuild config target
+        ...options.devServer?.config.esbuild,
+        loader: 'ts',
         sourcemap: options.sourceMap,
       },
       resolvedMap,

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -250,7 +250,7 @@ export async function transformMain(
       filename,
       {
         target: 'esnext',
-        // #430 Support decorators in .vue file. https://github.com/vitejs/vite-plugin-vue/issues/430
+        // #430 support decorators in .vue file
         // target can be overridden by esbuild config target
         ...options.devServer?.config.esbuild,
         loader: 'ts',


### PR DESCRIPTION
fix(plugin-vue): Support decorators in .vue file.

issues: https://github.com/vitejs/vite-plugin-vue/issues/430

More thoughts:
```
      {
        target: 'esnext',
        // #430 Support decorators in .vue file. https://github.com/vitejs/vite-plugin-vue/issues/430
        // target can be overridden by esbuild config target
        ...options.devServer?.config.esbuild,
        loader: 'ts',
        sourcemap: options.sourceMap,
      },
```
in vite-plugin-vue，There is no merge from esbuildTransformOptions, so submit the modification and merge esbuildTransformOptions, that is, options.devServer?.config.esbuild in the development environment

![image](https://github.com/user-attachments/assets/5e24f743-9843-4b23-b360-c746d331c8b6)

in vite vite:esbuild，Merged from esbuildTransformOptions

![image](https://github.com/user-attachments/assets/6fc89bb0-06da-4487-9fa6-e4df074aab0d)



Just for fault tolerance and compatibility considerations

vite is the basic component of vite-plugin-vue. When vite-plugin-vue calls the transformWithEsbuild function provided by vite:esbuild in the vite project, should it be consistent with the parameters of vite:esbuild calling transformWithEsbuild, that is, esbuildTransformOptions, that is, options.devServer?.config.esbuild in the development environment



Because the running results of vite in the development environment and the production environment should be consistent, it is also necessary to keep it consistent with the parameters passed in when vite:esbuild calls the transformWithEsbuild function

This code will only be triggered in the development environment, so it is correct to use options.devServer?.config.esbuild