### PR TITLE
test: handle vue-lib fixture for vite 6

### DIFF
--- a/playground/vue-lib/vite.config.lib.ts
+++ b/playground/vue-lib/vite.config.lib.ts
@@ -11,6 +11,10 @@ export default defineConfig({
       name: 'MyVueLib',
       formats: ['es'],
       fileName: 'my-vue-lib',
+      // Vite 6 only property to give a specific name to the css file.
+      // Set as "style" to match Vite 5 for testing purposes.
+      // @ts-expect-error
+      cssFileName: 'style',
     },
     rollupOptions: {
       external: ['vue'],


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Vite 6 library mode css file name now derives from the `package.json` `"name"` by default instead of always being `style.css`. This PR handles this case to work in both vite 5 and 6 by setting the new `build.lib.cssFileName` property.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
