### PR TITLE
test: remove deprecation warnings

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -2,6 +2,7 @@
   "name": "@vitejs/vite-playground",
   "private": true,
   "version": "1.0.0",
+  "type": "module",
   "devDependencies": {
     "@types/node": "^22.5.1",
     "convert-source-map": "^2.0.0",

--- a/playground/tailwind/package.json
+++ b/playground/tailwind/package.json
@@ -2,6 +2,7 @@
   "name": "@vitejs/test-tailwind",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/playground/tailwind/postcss.config.cts
+++ b/playground/tailwind/postcss.config.cts
@@ -1,4 +1,3 @@
-// postcss.config.ts
 module.exports = {
   plugins: {
     tailwindcss: { config: __dirname + '/tailwind.config.js' },

--- a/playground/vue-asset-base/package.json
+++ b/playground/vue-asset-base/package.json
@@ -2,6 +2,7 @@
   "name": "@vitejs/test-vue-server-origin",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/playground/vue-jsx/package.json
+++ b/playground/vue-jsx/package.json
@@ -2,6 +2,7 @@
   "name": "@vitejs/test-vue-jsx",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/playground/vue-jsx/vite.config.js
+++ b/playground/vue-jsx/vite.config.js
@@ -1,10 +1,8 @@
-const vueJsxPlugin = require('@vitejs/plugin-vue-jsx')
-const vuePlugin = require('@vitejs/plugin-vue')
+import { defineConfig } from 'vite'
+import vueJsxPlugin from '@vitejs/plugin-vue-jsx'
+import vuePlugin from '@vitejs/plugin-vue'
 
-/**
- * @type {import('vite').UserConfig}
- */
-module.exports = {
+export default defineConfig({
   plugins: [
     vueJsxPlugin({
       include: [/\.tesx$/, /\.[jt]sx$/],
@@ -39,4 +37,4 @@ export default defineComponent(() => {
   optimizeDeps: {
     disabled: true,
   },
-}
+})

--- a/playground/vue-legacy/package.json
+++ b/playground/vue-legacy/package.json
@@ -2,6 +2,7 @@
   "name": "@vitejs/test-vue-legacy",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/playground/vue-lib/package.json
+++ b/playground/vue-lib/package.json
@@ -2,6 +2,7 @@
   "name": "@vitejs/test-vue-lib",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev-consumer": "vite --config ./vite.config.consumer.ts",
     "build-lib": "vite build --config ./vite.config.lib.ts",

--- a/playground/vue-server-origin/package.json
+++ b/playground/vue-server-origin/package.json
@@ -2,6 +2,7 @@
   "name": "@vitejs/test-vue-server-origin",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/playground/vue-sourcemap/SassWithImport.vue
+++ b/playground/vue-sourcemap/SassWithImport.vue
@@ -4,7 +4,7 @@
 </template>
 
 <style lang="sass">
-@import './sassWithImportImported'
+@use './sassWithImportImported'
 
 .sass-with-import
   color: red

--- a/playground/vue-sourcemap/__tests__/__snapshots__/vue-sourcemap.spec.ts.snap
+++ b/playground/vue-sourcemap/__tests__/__snapshots__/vue-sourcemap.spec.ts.snap
@@ -268,7 +268,7 @@ exports[`serve:vue-sourcemap > sass with import > serve-sass-with-import 1`] = `
 </template>
 
 <style lang="sass">
-@import './sassWithImportImported'
+@use './sassWithImportImported'
 
 .sass-with-import
   color: red
@@ -308,7 +308,7 @@ exports[`serve:vue-sourcemap > src imported sass > serve-src-imported-sass 1`] =
     ".src-import-sass-imported
   color: red
 ",
-    "@import './src-import-imported'
+    "@use './src-import-imported'
 
 .src-import-sass
   color: red

--- a/playground/vue-sourcemap/package.json
+++ b/playground/vue-sourcemap/package.json
@@ -2,6 +2,7 @@
   "name": "@vitejs/test-vue-sourcemap",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/playground/vue-sourcemap/postcss.config.js
+++ b/playground/vue-sourcemap/postcss.config.js
@@ -1,3 +1,5 @@
-module.exports = {
-  plugins: [require('postcss-nested')],
+import postcssNested from 'postcss-nested'
+
+export default {
+  plugins: [postcssNested],
 }

--- a/playground/vue-sourcemap/src-import/src-import.sass
+++ b/playground/vue-sourcemap/src-import/src-import.sass
@@ -1,4 +1,4 @@
-@import './src-import-imported'
+@use './src-import-imported'
 
 .src-import-sass
   color: red

--- a/playground/vue/package.json
+++ b/playground/vue/package.json
@@ -2,6 +2,7 @@
   "name": "@vitejs/test-vue",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Use `"type": "module"` to remove Vite's CJS deprecation message
- Update `postcss.config.js` to handle ESM/CJS syntax
- Update scss to `@use` instead if `@import` as its deprecated (logs a warning in vite 6)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
