### PR TITLE
fix(plugin-vue): support external import URLs for monorepos

### DIFF
--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -330,6 +330,9 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin<Api> {
       // select corresponding block for sub-part virtual modules
       if (query.vue) {
         if (query.src) {
+          if (options.value.devServer?.watcher) {
+            options.value.devServer.watcher.add(filename)
+          }
           return fs.readFileSync(filename, 'utf-8')
         }
         const descriptor = getDescriptor(filename, options.value)!

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -330,9 +330,6 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin<Api> {
       // select corresponding block for sub-part virtual modules
       if (query.vue) {
         if (query.src) {
-          if (options.value.devServer?.watcher) {
-            options.value.devServer.watcher.add(filename)
-          }
           return fs.readFileSync(filename, 'utf-8')
         }
         const descriptor = getDescriptor(filename, options.value)!
@@ -389,6 +386,10 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin<Api> {
           ? getSrcDescriptor(filename, query) ||
             getTempSrcDescriptor(filename, query)
           : getDescriptor(filename, options.value)!
+
+        if (query.src) {
+          this.addWatchFile(filename)
+        }
 
         if (query.type === 'template') {
           return transformTemplateAsModule(

--- a/playground/vue-external/src-import/SrcImport.vue
+++ b/playground/vue-external/src-import/SrcImport.vue
@@ -1,0 +1,4 @@
+<style src="/#external/src-import/style.css" scoped></style>
+<style src="/#external/src-import/style2.css" scoped></style>
+<template src="./template.html"></template>
+<script src="./script.ts"></script>

--- a/playground/vue-external/src-import/css.module.css
+++ b/playground/vue-external/src-import/css.module.css
@@ -1,0 +1,7 @@
+.one {
+  background: yellow;
+}
+
+.two {
+  border: solid 1px red;
+}

--- a/playground/vue-external/src-import/script.ts
+++ b/playground/vue-external/src-import/script.ts
@@ -1,0 +1,19 @@
+import { defineComponent } from 'vue'
+import SrcImportStyle from './srcImportStyle.vue'
+import SrcImportStyle2 from './srcImportStyle2.vue'
+import SrcImportModuleStyle from './srcImportModuleStyle.vue'
+import SrcImportModuleStyle2 from './srcImportModuleStyle2.vue'
+
+export default defineComponent({
+  components: {
+    SrcImportStyle,
+    SrcImportStyle2,
+    SrcImportModuleStyle,
+    SrcImportModuleStyle2,
+  },
+  setup() {
+    return {
+      msg: 'hello from script src!',
+    }
+  },
+})

--- a/playground/vue-external/src-import/srcImportModuleStyle.vue
+++ b/playground/vue-external/src-import/srcImportModuleStyle.vue
@@ -1,0 +1,4 @@
+<template>
+  <div :class="$style.one">src for import css module</div>
+</template>
+<style lang="scss" module src="/#external/src-import/css.module.css" />

--- a/playground/vue-external/src-import/srcImportModuleStyle2.vue
+++ b/playground/vue-external/src-import/srcImportModuleStyle2.vue
@@ -1,0 +1,4 @@
+<template>
+  <div :class="$style.two">src for import css module</div>
+</template>
+<style lang="scss" module src="/#external/src-import/css.module.css" />

--- a/playground/vue-external/src-import/srcImportStyle.vue
+++ b/playground/vue-external/src-import/srcImportStyle.vue
@@ -1,0 +1,7 @@
+<style src="/#external/src-import/style.css" scoped></style>
+<template>
+  <div class="src-imports-script">{{ msg }}</div>
+</template>
+<script setup>
+const msg = 'hello from component A!'
+</script>

--- a/playground/vue-external/src-import/srcImportStyle2.vue
+++ b/playground/vue-external/src-import/srcImportStyle2.vue
@@ -1,0 +1,4 @@
+<style src="/#external/src-import/style2.css" scoped></style>
+<template>
+  <div class="src-imports-style">This should be tan</div>
+</template>

--- a/playground/vue-external/src-import/style.css
+++ b/playground/vue-external/src-import/style.css
@@ -1,0 +1,3 @@
+.external-src-imports-style {
+  color: tan;
+}

--- a/playground/vue-external/src-import/style2.css
+++ b/playground/vue-external/src-import/style2.css
@@ -1,0 +1,3 @@
+.external-src-imports-script {
+  color: #0088ff;
+}

--- a/playground/vue-external/src-import/template.html
+++ b/playground/vue-external/src-import/template.html
@@ -1,0 +1,7 @@
+<h2>External SFC Src Imports</h2>
+<div class="external-src-imports-script">{{ msg }}</div>
+<div class="external-src-imports-style">This should be tan</div>
+<SrcImportStyle></SrcImportStyle>
+<SrcImportStyle2></SrcImportStyle2>
+<SrcImportModuleStyle></SrcImportModuleStyle>
+<SrcImportModuleStyle2></SrcImportModuleStyle2>

--- a/playground/vue/Main.vue
+++ b/playground/vue/Main.vue
@@ -18,6 +18,7 @@
   <Assets />
   <CustomBlock />
   <SrcImport />
+  <ExternalSrcImport />
   <Slotted>
     <div class="slotted">this should be red</div>
   </Slotted>
@@ -48,6 +49,7 @@ import CssModules from './CssModules.vue'
 import Assets from './Assets.vue'
 import CustomBlock from './CustomBlock.vue'
 import SrcImport from './src-import/SrcImport.vue'
+import ExternalSrcImport from '#external/src-import/SrcImport.vue'
 import Slotted from './Slotted.vue'
 import ScanDep from './ScanDep.vue'
 import TsImport from './TsImport.vue'

--- a/playground/vue/__tests__/vue.spec.ts
+++ b/playground/vue/__tests__/vue.spec.ts
@@ -280,6 +280,38 @@ describe('src imports', () => {
   })
 })
 
+describe('external src imports', () => {
+  test('script src with ts', async () => {
+    expect(await page.textContent('.external-src-imports-script')).toMatch(
+      'hello from script src',
+    )
+    editFile('../vue-external/src-import/script.ts', (code) =>
+      code.replace('hello from script src', 'updated'),
+    )
+    await untilUpdated(
+      () => page.textContent('.external-src-imports-script'),
+      'updated',
+    )
+  })
+
+  test('style src', async () => {
+    const el = await page.$('.external-src-imports-style')
+    expect(await getColor(el)).toBe('tan')
+    editFile('../vue-external/src-import/style.css', (code) =>
+      code.replace('color: tan', 'color: red'),
+    )
+    await untilUpdated(() => getColor(el), 'red')
+  })
+
+  test('template src import hmr', async () => {
+    const el = await page.$('.external-src-imports-style')
+    editFile('../vue-external/src-import/template.html', (code) =>
+      code.replace('should be tan', 'should be red'),
+    )
+    await untilUpdated(() => el.textContent(), 'should be red')
+  })
+})
+
 describe('custom blocks', () => {
   test('should work', async () => {
     expect(await page.textContent('.custom-block')).toMatch('こんにちは')

--- a/playground/vue/vite.config.ts
+++ b/playground/vue/vite.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
     alias: {
       '/@': __dirname,
       '@': __dirname,
+      '#external': resolve(__dirname, '../vue-external'),
+      '/#external': resolve(__dirname, '../vue-external'),
     },
   },
   plugins: [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently vue-plugin ignore watcher and use default vite config for it (root without node_modules), it not worked for monorepo's. And hmr not worked for shared script/style with src like this, but worked for .vue (reason later)

```
// node_modules/shared/index.vue
<template>
  <div> foo</div>
</template>

<script src="./index.ts"></script>

// node_modules/shared/index.ts
export default defineComponent({
  ...
})
```

In contrast of this internal vite-esbuild plugin add imports to watcher (because of it `.vue` hmr worked, because it imports from ts/js)

fix #397 

### Additional context

By default `vite` doesn't support hmr for `node_modules`, we enable it by https://github.com/vitejs/vite/issues/8619#issuecomment-2606507049

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
