### PR TITLE
feat(css): tree shake scoped styles

### DIFF
--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -13,6 +13,7 @@ import { version } from '../package.json'
 import { resolveCompiler } from './compiler'
 import { parseVueRequest } from './utils/query'
 import {
+  type ExtendedSFCDescriptor,
   getDescriptor,
   getSrcDescriptor,
   getTempSrcDescriptor,
@@ -382,7 +383,7 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin<Api> {
         )
       } else {
         // sub block request
-        const descriptor = query.src
+        const descriptor: ExtendedSFCDescriptor = query.src
           ? getSrcDescriptor(filename, query) ||
             getTempSrcDescriptor(filename, query)
           : getDescriptor(filename, options.value)!

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -275,9 +275,9 @@ export async function transformMain(
 
   return {
     code: resolvedCode,
-    map: resolvedMap || {
+    map: (resolvedMap || {
       mappings: '',
-    },
+    }) as any,
     meta: {
       vite: {
         lang: descriptor.script?.lang || descriptor.scriptSetup?.lang || 'js',

--- a/packages/plugin-vue/src/style.ts
+++ b/packages/plugin-vue/src/style.ts
@@ -62,5 +62,12 @@ export async function transformStyle(
   return {
     code: result.code,
     map: map,
+    meta: block.scoped
+      ? {
+          vite: {
+            cssScopeTo: [descriptor.filename, 'default'],
+          },
+        }
+      : undefined,
   }
 }

--- a/packages/plugin-vue/src/style.ts
+++ b/packages/plugin-vue/src/style.ts
@@ -1,13 +1,13 @@
-import type { SFCDescriptor } from 'vue/compiler-sfc'
 import type { ExistingRawSourceMap, TransformPluginContext } from 'rollup'
 import type { RawSourceMap } from 'source-map-js'
 import { formatPostcssSourceMap } from 'vite'
+import type { ExtendedSFCDescriptor } from './utils/descriptorCache'
 import type { ResolvedOptions } from './index'
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function transformStyle(
   code: string,
-  descriptor: SFCDescriptor,
+  descriptor: ExtendedSFCDescriptor,
   index: number,
   options: ResolvedOptions,
   pluginContext: TransformPluginContext,
@@ -62,12 +62,13 @@ export async function transformStyle(
   return {
     code: result.code,
     map: map,
-    meta: block.scoped
-      ? {
-          vite: {
-            cssScopeTo: [descriptor.filename, 'default'],
-          },
-        }
-      : undefined,
+    meta:
+      block.scoped && !descriptor.isTemp
+        ? {
+            vite: {
+              cssScopeTo: [descriptor.filename, 'default'],
+            },
+          }
+        : undefined,
   }
 }

--- a/packages/plugin-vue/src/utils/descriptorCache.ts
+++ b/packages/plugin-vue/src/utils/descriptorCache.ts
@@ -75,6 +75,10 @@ export function invalidateDescriptor(filename: string, hmr = false): void {
   }
 }
 
+export interface ExtendedSFCDescriptor extends SFCDescriptor {
+  isTemp?: boolean
+}
+
 export function getDescriptor(
   filename: string,
   options: ResolvedOptions,
@@ -113,7 +117,7 @@ export function getSrcDescriptor(
 export function getTempSrcDescriptor(
   filename: string,
   query: VueQuery,
-): SFCDescriptor {
+): ExtendedSFCDescriptor {
   // this is only used for pre-compiled <style src> with scoped flag
   return {
     filename,
@@ -124,9 +128,10 @@ export function getTempSrcDescriptor(
         loc: {
           start: { line: 0, column: 0 },
         },
-      },
+      } as any,
     ],
-  } as SFCDescriptor
+    isTemp: true,
+  } as ExtendedSFCDescriptor
 }
 
 export function setSrcDescriptor(

--- a/playground/ssr-vue/vite.config.js
+++ b/playground/ssr-vue/vite.config.js
@@ -93,7 +93,9 @@ export default defineConfig(({ command, ssrBuild, isSsrBuild }) => ({
           ) {
             return {
               code:
-                `import { __ssr_vue_processAssetPath } from '${virtualId}';__ssr_vue_processAssetPath;` +
+                `import { __ssr_vue_processAssetPath } from '${virtualId}';` +
+                // make `__ssr_vue_processAssetPath` not to be tree-shaken (`globalThis.__ssr_vue` doesn't exist)
+                `globalThis.__ssr_vue?.(__ssr_vue_processAssetPath);` +
                 code,
               sourcemap: null, // no sourcemap support to speed up CI
             }

--- a/playground/vue/Main.vue
+++ b/playground/vue/Main.vue
@@ -66,6 +66,12 @@ import PreCompiledExternalScoped from './pre-compiled/external-scoped.vue'
 import PreCompiledExternalCssModules from './pre-compiled/external-cssmodules.vue'
 import ParserOptions from './ParserOptions.vue'
 import HmrCircularReference from './HmrCircularReference.vue'
+import TreeShakeScopedStyle from './TreeShakeScopedStyle.vue'
+
+// NOTE: this function is not used intentionally
+function foo() {
+  console.log(TreeShakeScopedStyle)
+}
 
 const TsGeneric = defineAsyncComponent(() => import('./TsGeneric.vue'))
 

--- a/playground/vue/TreeShakeScopedStyle.vue
+++ b/playground/vue/TreeShakeScopedStyle.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>tree shake scoped style</div>
+</template>
+
+<style scoped>
+.tree-shake-scoped-style {
+  color: red;
+}
+</style>

--- a/playground/vue/__tests__/vue.spec.ts
+++ b/playground/vue/__tests__/vue.spec.ts
@@ -3,6 +3,7 @@ import { version } from 'vue'
 import {
   browserLogs,
   editFile,
+  findAssetFile,
   getBg,
   getColor,
   isBuild,
@@ -440,4 +441,9 @@ describe('template parse options', () => {
       'custom',
     )
   })
+})
+
+test.runIf(isBuild)('scoped style should be tree-shakeable', async () => {
+  const indexCss = findAssetFile(/index-[\w-]+\.css/)
+  expect(indexCss).not.toContain('.tree-shake-scoped-style')
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Since the scoped styles in Vue generates styles scoped to that component, it can be tree shaken if that component is not used. (normal styles cannot be tree shaken as it can be used from other components).

This PR requires https://github.com/vitejs/vite-plugin-vue/pull/526 and it uses a recently introduced feature in Vite (https://github.com/vitejs/vite/pull/19418).

I tested this feature with https://vitepress.new/ and I got 8kB CSS file reduction.

Technically you can have a scoped style like below
```css
:global(.foo) {
  color: red;
}
```
and this would be treeshaken where you might not expect to. If we should handle this case, we can add an additional condition of `!code.includes(':global')`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
