### PR TITLE
fix(plugin-vue): ensure HMR updates styles when SFC is treated as a type dependency

### DIFF
--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -31,6 +31,7 @@ export async function handleHotUpdate(
   { file, modules, read }: HmrContext,
   options: ResolvedOptions,
   customElement: boolean,
+  typeDepModules?: ModuleNode[],
 ): Promise<ModuleNode[] | void> {
   const prevDescriptor = getDescriptor(file, options, false, true)
   if (!prevDescriptor) {
@@ -172,7 +173,9 @@ export async function handleHotUpdate(
     }
     debug(`[vue:update(${updateType.join('&')})] ${file}`)
   }
-  return [...affectedModules].filter(Boolean) as ModuleNode[]
+  return [...affectedModules, ...(typeDepModules || [])].filter(
+    Boolean,
+  ) as ModuleNode[]
 }
 
 export function isEqualBlock(a: SFCBlock | null, b: SFCBlock | null): boolean {

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs'
-import type { Plugin, ViteDevServer } from 'vite'
+import type { ModuleNode, Plugin, ViteDevServer } from 'vite'
 import { createFilter, normalizePath } from 'vite'
 import type {
   SFCBlock,
@@ -224,16 +224,22 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin<Api> {
       if (options.value.compiler.invalidateTypeCache) {
         options.value.compiler.invalidateTypeCache(ctx.file)
       }
+
+      let typeDepModules: ModuleNode[] | undefined
       const matchesFilter = filter.value(ctx.file)
       if (typeDepToSFCMap.has(ctx.file)) {
-        const mod = handleTypeDepChange(typeDepToSFCMap.get(ctx.file)!, ctx)
-        if (!matchesFilter) return mod
+        typeDepModules = handleTypeDepChange(
+          typeDepToSFCMap.get(ctx.file)!,
+          ctx,
+        )
+        if (!matchesFilter) return typeDepModules
       }
       if (matchesFilter) {
         return handleHotUpdate(
           ctx,
           options.value,
           customElementFilter.value(ctx.file),
+          typeDepModules,
         )
       }
     },

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -224,10 +224,12 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin<Api> {
       if (options.value.compiler.invalidateTypeCache) {
         options.value.compiler.invalidateTypeCache(ctx.file)
       }
+      const matchesFilter = filter.value(ctx.file)
       if (typeDepToSFCMap.has(ctx.file)) {
-        return handleTypeDepChange(typeDepToSFCMap.get(ctx.file)!, ctx)
+        const mod = handleTypeDepChange(typeDepToSFCMap.get(ctx.file)!, ctx)
+        if (!matchesFilter) return mod
       }
-      if (filter.value(ctx.file)) {
+      if (matchesFilter) {
         return handleHotUpdate(
           ctx,
           options.value,

--- a/playground/vue/ExportTypeProps1.vue
+++ b/playground/vue/ExportTypeProps1.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="export-type-props1">foo: {{ title }}</div>
+</template>
+
+<script lang="ts">
+export interface FooProps {
+  title?: string
+}
+</script>
+
+<script setup lang="ts">
+defineProps<FooProps>()
+</script>
+
+<style>
+.export-type-props1 {
+  color: red;
+}
+</style>

--- a/playground/vue/ExportTypeProps1.vue
+++ b/playground/vue/ExportTypeProps1.vue
@@ -1,15 +1,15 @@
 <template>
-  <div class="export-type-props1">foo: {{ title }}</div>
+  <div class="export-type-props1">{{ props }}</div>
 </template>
 
 <script lang="ts">
 export interface FooProps {
-  title?: string
+  msg: string
 }
 </script>
 
 <script setup lang="ts">
-defineProps<FooProps>()
+const props = defineProps<FooProps>()
 </script>
 
 <style>

--- a/playground/vue/ExportTypeProps2.vue
+++ b/playground/vue/ExportTypeProps2.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+import type { FooProps } from './ExportTypeProps1.vue'
+defineProps<FooProps>()
+</script>
+
+<template>
+  <div>bar: {{ title }}</div>
+</template>

--- a/playground/vue/ExportTypeProps2.vue
+++ b/playground/vue/ExportTypeProps2.vue
@@ -1,8 +1,8 @@
+<template>
+  <div class="export-type-props2">{{ props }}</div>
+</template>
+
 <script setup lang="ts">
 import type { FooProps } from './ExportTypeProps1.vue'
-defineProps<FooProps>()
+const props = defineProps<FooProps>()
 </script>
-
-<template>
-  <div>bar: {{ title }}</div>
-</template>

--- a/playground/vue/Main.vue
+++ b/playground/vue/Main.vue
@@ -36,6 +36,8 @@
   <PreCompiledExternalScoped />
   <PreCompiledExternalCssModules />
   <ParserOptions />
+  <ExportTypeProps1 />
+  <ExportTypeProps2 />
 </template>
 
 <script setup lang="ts">
@@ -66,6 +68,8 @@ import PreCompiledExternalScoped from './pre-compiled/external-scoped.vue'
 import PreCompiledExternalCssModules from './pre-compiled/external-cssmodules.vue'
 import ParserOptions from './ParserOptions.vue'
 import HmrCircularReference from './HmrCircularReference.vue'
+import ExportTypeProps1 from './ExportTypeProps1.vue'
+import ExportTypeProps2 from './ExportTypeProps2.vue'
 
 const TsGeneric = defineAsyncComponent(() => import('./TsGeneric.vue'))
 

--- a/playground/vue/Main.vue
+++ b/playground/vue/Main.vue
@@ -36,8 +36,8 @@
   <PreCompiledExternalScoped />
   <PreCompiledExternalCssModules />
   <ParserOptions />
-  <ExportTypeProps1 />
-  <ExportTypeProps2 />
+  <ExportTypeProps1 msg="msg" />
+  <ExportTypeProps2 msg="msg" />
 </template>
 
 <script setup lang="ts">

--- a/playground/vue/__tests__/vue.spec.ts
+++ b/playground/vue/__tests__/vue.spec.ts
@@ -409,6 +409,13 @@ describe('macro imported types', () => {
       ),
     )
   })
+
+  test('should update style', async () => {
+    const cls = '.export-type-props1'
+    expect(await getColor(cls)).toBe('red')
+    editFile('ExportTypeProps1.vue', (code) => code.replace('red', 'blue'))
+    await untilUpdated(() => getColor(cls), 'blue')
+  })
 })
 
 test('TS with generics', async () => {

--- a/playground/vue/__tests__/vue.spec.ts
+++ b/playground/vue/__tests__/vue.spec.ts
@@ -410,11 +410,18 @@ describe('macro imported types', () => {
     )
   })
 
-  test('should update style', async () => {
-    const cls = '.export-type-props1'
-    expect(await getColor(cls)).toBe('red')
+  test('should hmr when SFC is treated as a type dependency', async () => {
+    const cls1 = '.export-type-props1'
+    expect(await getColor(cls1)).toBe('red')
     editFile('ExportTypeProps1.vue', (code) => code.replace('red', 'blue'))
-    await untilUpdated(() => getColor(cls), 'blue')
+    await untilUpdated(() => getColor(cls1), 'blue')
+
+    const cls2 = '.export-type-props2'
+    editFile('ExportTypeProps1.vue', (code) => code.replace('msg: string', ''))
+    await untilUpdated(
+      () => page.textContent(cls2),
+      JSON.stringify({}, null, 2),
+    )
   })
 })
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
close https://github.com/vuejs/core/issues/13008

Fix HMR when an SFC exporting a type is treated as a type dependency. Ensure the SFC itself triggers an update instead of relying only on type dependency handling, preventing outdated transforms from applying and causing incorrect updates. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
