### PR TITLE
test: fix deprecated third argument options

### DIFF
--- a/playground/ssr-vue/__tests__/ssr-vue.spec.ts
+++ b/playground/ssr-vue/__tests__/ssr-vue.spec.ts
@@ -166,18 +166,14 @@ test('hydration', async () => {
   expect(await page.textContent('button')).toMatch('1')
 })
 
-test(
-  'hmr',
-  async () => {
-    // This is test is flaky in Mac CI, but can't be reproduced locally. Wait until
-    // network idle to avoid the issue. TODO: This may be caused by a bug when
-    // modifying a file while loading, we should remove this guard
-    await page.goto(url, { waitUntil: 'networkidle' })
-    editFile('src/pages/Home.vue', (code) => code.replace('Home', 'changed'))
-    await untilUpdated(() => page.textContent('h1'), 'changed')
-  },
-  { retry: 3 },
-)
+test('hmr', { retry: 3 }, async () => {
+  // This is test is flaky in Mac CI, but can't be reproduced locally. Wait until
+  // network idle to avoid the issue. TODO: This may be caused by a bug when
+  // modifying a file while loading, we should remove this guard
+  await page.goto(url, { waitUntil: 'networkidle' })
+  editFile('src/pages/Home.vue', (code) => code.replace('Home', 'changed'))
+  await untilUpdated(() => page.textContent('h1'), 'changed')
+})
 
 test('client navigation', async () => {
   await untilBrowserLogAfter(() => page.goto(url), 'hydrated')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

this is deprecated and a warning was output.
https://vitest.dev/guide/migration.html#test-options-as-a-third-argument

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
