### PR TITLE
chore: use rollup types exposed from Vite

### DIFF
--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -1,12 +1,12 @@
 import path from 'node:path'
 import fs from 'node:fs'
 import type { SFCBlock, SFCDescriptor } from 'vue/compiler-sfc'
-import type { PluginContext, TransformPluginContext } from 'rollup'
 import type { RawSourceMap } from 'source-map-js'
 import type { EncodedSourceMap as TraceEncodedSourceMap } from '@jridgewell/trace-mapping'
 import { TraceMap, eachMapping } from '@jridgewell/trace-mapping'
 import type { EncodedSourceMap as GenEncodedSourceMap } from '@jridgewell/gen-mapping'
 import { addMapping, fromMap, toEncodedMap } from '@jridgewell/gen-mapping'
+import type { Rollup } from 'vite'
 import { normalizePath, transformWithEsbuild } from 'vite'
 import {
   createDescriptor,
@@ -31,7 +31,7 @@ export async function transformMain(
   code: string,
   filename: string,
   options: ResolvedOptions,
-  pluginContext: TransformPluginContext,
+  pluginContext: Rollup.TransformPluginContext,
   ssr: boolean,
   customElement: boolean,
 ) {
@@ -290,7 +290,7 @@ export async function transformMain(
 async function genTemplateCode(
   descriptor: SFCDescriptor,
   options: ResolvedOptions,
-  pluginContext: PluginContext,
+  pluginContext: Rollup.PluginContext,
   ssr: boolean,
   customElement: boolean,
 ) {
@@ -339,7 +339,7 @@ async function genTemplateCode(
 async function genScriptCode(
   descriptor: SFCDescriptor,
   options: ResolvedOptions,
-  pluginContext: PluginContext,
+  pluginContext: Rollup.PluginContext,
   ssr: boolean,
   customElement: boolean,
 ): Promise<{
@@ -397,7 +397,7 @@ async function genScriptCode(
 
 async function genStyleCode(
   descriptor: SFCDescriptor,
-  pluginContext: PluginContext,
+  pluginContext: Rollup.PluginContext,
   customElement: boolean,
   attachedProps: [string, string][],
 ) {
@@ -487,7 +487,7 @@ function genCSSModulesCode(
 
 async function genCustomBlockCode(
   descriptor: SFCDescriptor,
-  pluginContext: PluginContext,
+  pluginContext: Rollup.PluginContext,
 ) {
   let code = ''
   for (let index = 0; index < descriptor.customBlocks.length; index++) {
@@ -514,7 +514,7 @@ async function genCustomBlockCode(
 async function linkSrcToDescriptor(
   src: string,
   descriptor: SFCDescriptor,
-  pluginContext: PluginContext,
+  pluginContext: Rollup.PluginContext,
   scoped?: boolean,
 ) {
   const srcFile =

--- a/packages/plugin-vue/src/style.ts
+++ b/packages/plugin-vue/src/style.ts
@@ -1,5 +1,5 @@
-import type { ExistingRawSourceMap, TransformPluginContext } from 'rollup'
 import type { RawSourceMap } from 'source-map-js'
+import type { Rollup } from 'vite'
 import { formatPostcssSourceMap } from 'vite'
 import type { ExtendedSFCDescriptor } from './utils/descriptorCache'
 import type { ResolvedOptions } from './index'
@@ -10,7 +10,7 @@ export async function transformStyle(
   descriptor: ExtendedSFCDescriptor,
   index: number,
   options: ResolvedOptions,
-  pluginContext: TransformPluginContext,
+  pluginContext: Rollup.TransformPluginContext,
   filename: string,
 ) {
   const block = descriptor.styles[index]
@@ -54,7 +54,10 @@ export async function transformStyle(
     ? await formatPostcssSourceMap(
         // version property of result.map is declared as string
         // but actually it is a number
-        result.map as Omit<RawSourceMap, 'version'> as ExistingRawSourceMap,
+        result.map as Omit<
+          RawSourceMap,
+          'version'
+        > as Rollup.ExistingRawSourceMap,
         filename,
       )
     : ({ mappings: '' } as any)

--- a/packages/plugin-vue/src/template.ts
+++ b/packages/plugin-vue/src/template.ts
@@ -6,7 +6,7 @@ import type {
   SFCTemplateCompileOptions,
   SFCTemplateCompileResults,
 } from 'vue/compiler-sfc'
-import type { PluginContext, TransformPluginContext } from 'rollup'
+import type { Rollup } from 'vite'
 import { getResolvedScript, resolveScript } from './script'
 import { createRollupError } from './utils/error'
 import type { ResolvedOptions } from './index'
@@ -15,7 +15,7 @@ export async function transformTemplateAsModule(
   code: string,
   descriptor: SFCDescriptor,
   options: ResolvedOptions,
-  pluginContext: TransformPluginContext,
+  pluginContext: Rollup.TransformPluginContext,
   ssr: boolean,
   customElement: boolean,
 ): Promise<{
@@ -56,7 +56,7 @@ export function transformTemplateInMain(
   code: string,
   descriptor: SFCDescriptor,
   options: ResolvedOptions,
-  pluginContext: PluginContext,
+  pluginContext: Rollup.PluginContext,
   ssr: boolean,
   customElement: boolean,
 ): SFCTemplateCompileResults {
@@ -82,7 +82,7 @@ export function compile(
   code: string,
   descriptor: SFCDescriptor,
   options: ResolvedOptions,
-  pluginContext: PluginContext,
+  pluginContext: Rollup.PluginContext,
   ssr: boolean,
   customElement: boolean,
 ) {

--- a/packages/plugin-vue/src/utils/error.ts
+++ b/packages/plugin-vue/src/utils/error.ts
@@ -1,12 +1,12 @@
 import type { CompilerError } from 'vue/compiler-sfc'
-import type { RollupError } from 'rollup'
+import type { Rollup } from 'vite'
 
 export function createRollupError(
   id: string,
   error: CompilerError | SyntaxError,
-): RollupError {
+): Rollup.RollupError {
   const { message, name, stack } = error
-  const rollupError: RollupError = {
+  const rollupError: Rollup.RollupError = {
     id,
     plugin: 'vue',
     message,

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -8,6 +8,7 @@ import type {
   Logger,
   PluginOption,
   ResolvedConfig,
+  Rollup,
   UserConfig,
   ViteDevServer,
 } from 'vite'
@@ -19,7 +20,6 @@ import {
   preview,
 } from 'vite'
 import type { Browser, Page } from 'playwright-chromium'
-import type { RollupError, RollupWatcher, RollupWatcherEvent } from 'rollup'
 import type { File } from 'vitest'
 import { beforeAll } from 'vitest'
 
@@ -72,7 +72,7 @@ export let resolvedConfig: ResolvedConfig = undefined!
 export let page: Page = undefined!
 export let browser: Browser = undefined!
 export let viteTestUrl: string = ''
-export let watcher: RollupWatcher | undefined = undefined
+export let watcher: Rollup.RollupWatcher | undefined = undefined
 
 declare module 'vite' {
   interface InlineConfig {
@@ -269,7 +269,7 @@ export async function startDefaultServe(): Promise<void> {
     const isWatch = !!resolvedConfig!.build.watch
     // in build watch,call startStaticServer after the build is complete
     if (isWatch) {
-      watcher = rollupOutput as RollupWatcher
+      watcher = rollupOutput as Rollup.RollupWatcher
       await notifyRebuildComplete(watcher)
     }
     // @ts-ignore
@@ -290,10 +290,10 @@ export async function startDefaultServe(): Promise<void> {
  * Send the rebuild complete message in build watch
  */
 export async function notifyRebuildComplete(
-  watcher: RollupWatcher,
-): Promise<RollupWatcher> {
+  watcher: Rollup.RollupWatcher,
+): Promise<Rollup.RollupWatcher> {
   let resolveFn: undefined | (() => void)
-  const callback = (event: RollupWatcherEvent): void => {
+  const callback = (event: Rollup.RollupWatcherEvent): void => {
     if (event.code === 'END') {
       resolveFn?.()
     }
@@ -306,7 +306,7 @@ export async function notifyRebuildComplete(
 }
 
 function createInMemoryLogger(logs: string[]): Logger {
-  const loggedErrors = new WeakSet<Error | RollupError>()
+  const loggedErrors = new WeakSet<Error | Rollup.RollupError>()
   const warnedMessages = new Set<string>()
 
   const logger: Logger = {

--- a/playground/vue-lib/__tests__/vue-lib.spec.ts
+++ b/playground/vue-lib/__tests__/vue-lib.spec.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
+import type { Rollup } from 'vite'
 import { build } from 'vite'
 import { describe, expect, test } from 'vitest'
-import type { OutputChunk, RollupOutput } from 'rollup'
 
 describe('vue component library', () => {
   test('should output tree shakeable css module code', async () => {
@@ -14,10 +14,10 @@ describe('vue component library', () => {
     const { output } = (await build({
       logLevel: 'silent',
       configFile: path.resolve(__dirname, '../vite.config.consumer.ts'),
-    })) as RollupOutput
+    })) as Rollup.RollupOutput
     const { code } = output.find(
       (e) => e.type === 'chunk' && e.isEntry,
-    ) as OutputChunk
+    ) as Rollup.OutputChunk
     // Unused css module should be treeshaked
     expect(code).toContain('styleA') // styleA is used by CompA
     expect(code).not.toContain('styleB') // styleB is not used


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Use rollup types exposed from Vite. This will make ecosystem-ci w/ rolldown-vite run without type errors (one test fail due to lib mode not supported).

The rollup types were exposed since Vite 4.2.0 (https://github.com/vitejs/vite/commit/6e49e5284a5ee5bdae801d2fcbd594a49a7694b4). This is fine because plugin-vue only supports Vite 5+.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
