### PR TITLE
feat(plugin-vue): use `transformWithOxc` if `rolldown-vite` is detected

### DIFF
--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -263,12 +263,11 @@ export async function transformMain(
         resolvedCode,
         filename,
         {
-          target: 'esnext',
-          charset: 'utf8',
           // #430 support decorators in .vue file
-          // target can be overridden by esbuild config target
-          ...options.devServer?.config.esbuild,
-          loader: 'ts',
+          // target can be overridden by oxc config target
+          // @ts-ignore Rolldown-specific
+          ...options.devServer?.config.oxc,
+          lang: 'ts',
           sourcemap: options.sourceMap,
         },
         resolvedMap,

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -257,8 +257,8 @@ export async function transformMain(
     !descriptor.script?.src // only normal script can have src
   ) {
     // @ts-ignore Rolldown-specific
-    const { rolldownVersion, transformWithOxc } = await import('vite')
-    if (rolldownVersion) {
+    const { transformWithOxc } = await import('vite')
+    if (transformWithOxc) {
       const { code, map } = await transformWithOxc(
         resolvedCode,
         filename,

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -256,22 +256,43 @@ export async function transformMain(
     /tsx?$/.test(lang) &&
     !descriptor.script?.src // only normal script can have src
   ) {
-    const { code, map } = await transformWithEsbuild(
-      resolvedCode,
-      filename,
-      {
-        target: 'esnext',
-        charset: 'utf8',
-        // #430 support decorators in .vue file
-        // target can be overridden by esbuild config target
-        ...options.devServer?.config.esbuild,
-        loader: 'ts',
-        sourcemap: options.sourceMap,
-      },
-      resolvedMap,
-    )
-    resolvedCode = code
-    resolvedMap = resolvedMap ? (map as any) : resolvedMap
+    // @ts-ignore Rolldown-specific
+    const { rolldownVersion, transformWithOxc } = await import('vite')
+    if (rolldownVersion) {
+      const { code, map } = await transformWithOxc(
+        resolvedCode,
+        filename,
+        {
+          target: 'esnext',
+          charset: 'utf8',
+          // #430 support decorators in .vue file
+          // target can be overridden by esbuild config target
+          ...options.devServer?.config.esbuild,
+          loader: 'ts',
+          sourcemap: options.sourceMap,
+        },
+        resolvedMap,
+      )
+      resolvedCode = code
+      resolvedMap = resolvedMap ? (map as any) : resolvedMap
+    } else {
+      const { code, map } = await transformWithEsbuild(
+        resolvedCode,
+        filename,
+        {
+          target: 'esnext',
+          charset: 'utf8',
+          // #430 support decorators in .vue file
+          // target can be overridden by esbuild config target
+          ...options.devServer?.config.esbuild,
+          loader: 'ts',
+          sourcemap: options.sourceMap,
+        },
+        resolvedMap,
+      )
+      resolvedCode = code
+      resolvedMap = resolvedMap ? (map as any) : resolvedMap
+    }
   }
 
   return {


### PR DESCRIPTION
### Description

When [using `rolldown-vite`](https://vite.dev/guide/rolldown#transformwithesbuild-requires-esbuild-to-be-installed-separately), one needs to install esbuild at the moment as `transformWithEsbuild` is used. Instead, this PR uses the exported `transformWithOxc` function if available.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
