### PR TITLE
fix(vue): import with query

### DIFF
--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -9,7 +9,10 @@ import type {
 } from 'vue/compiler-sfc'
 import type * as _compiler from 'vue/compiler-sfc'
 import { computed, shallowRef } from 'vue'
-import { exactRegex } from '@rolldown/pluginutils'
+import {
+  exactRegex,
+  makeIdFiltersToMatchWithQuery,
+} from '@rolldown/pluginutils'
 import { version } from '../package.json'
 import { resolveCompiler } from './compiler'
 import { parseVueRequest } from './utils/query'
@@ -358,7 +361,10 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin<Api> {
       optionsHookIsCalled = true
       ;(plugin.transform as TransformObjectHook).filter = {
         id: {
-          include: [...ensureArray(include.value), /[?&]vue\b/],
+          include: [
+            ...makeIdFiltersToMatchWithQuery(ensureArray(include.value)),
+            /[?&]vue\b/,
+          ],
           exclude: exclude.value,
         },
       }

--- a/playground/vue/Main.vue
+++ b/playground/vue/Main.vue
@@ -11,6 +11,7 @@
   <HmrCircularReference name="test" />
   <TypeProps msg="msg" bar="bar" :id="123" />
   <TypePropsTsx msg="msg" bar="bar" />
+  <WithQuery />
   <Syntax />
   <PreProcessors />
   <PreProcessorsHmr />
@@ -44,6 +45,7 @@
 import { version, defineAsyncComponent } from 'vue'
 import Hmr from './Hmr.vue'
 import HmrTsx from './HmrTsx.vue'
+import WithQuery from './WithQuery.vue?with-query'
 import Syntax from './Syntax.vue'
 import PreProcessors from './PreProcessors.vue'
 import PreProcessorsHmr from './PreProcessorsHmr.vue'

--- a/playground/vue/WithQuery.vue
+++ b/playground/vue/WithQuery.vue
@@ -1,0 +1,8 @@
+<template>
+  <h2>Imported with query</h2>
+  <p class="imported-with-query">{{ foo }}</p>
+</template>
+
+<script setup>
+const foo = 'ok'
+</script>

--- a/playground/vue/__tests__/vue.spec.ts
+++ b/playground/vue/__tests__/vue.spec.ts
@@ -22,6 +22,10 @@ test('should update', async () => {
   expect(await page.textContent('.hmr-inc')).toMatch('count is 1')
 })
 
+test('import with query should work', async () => {
+  expect(await page.textContent('.imported-with-query')).toMatch('ok')
+})
+
 test('template/script latest syntax support', async () => {
   expect(await page.textContent('.syntax')).toBe('baz')
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes a regression caused by #582.
`import WithQuery from './WithQuery.vue?with-query'` was not working.

This PR fixes this ecosystem-ci failure:
https://github.com/vitejs/vite-ecosystem-ci/actions/runs/15291891294/job/43012757731#step:8:2275

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
