### PR TITLE
feat(vue-jsx): allow esbuild to perform ts transformation

### DIFF
--- a/packages/plugin-vue-jsx/README.md
+++ b/packages/plugin-vue-jsx/README.md
@@ -43,6 +43,34 @@ Default: `['defineComponent']`
 
 The name of the function to be used for defining components. This is useful when you have a custom `defineComponent` function.
 
+### tsTransform
+
+Type: `'babel' | 'built-in'`
+
+Default: `'babel'`
+
+Defines how `typescript` transformation is handled for `.tsx` files.
+
+`'babel'` - `typescript` transformation is handled by `@babel/plugin-transform-typescript` during `babel` invocation for JSX transformation.
+
+`'built-in'` - `babel` is invoked only for JSX transformation and then `typescript` transformation is handled by the same toolchain used for `.ts` files (currently `esbuild`).
+
+### babelPlugins
+
+Type: `any[]`
+
+Default: `undefined`
+
+Provide additional plugins for `babel` invocation for JSX transformation.
+
+### tsPluginOptions
+
+Type: `any`
+
+Default: `undefined`
+
+Defines options for `@babel/plugin-transform-typescript` plugin.
+
 ## HMR Detection
 
 This plugin supports HMR of Vue JSX components. The detection requirements are:

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue-jsx#readme",
   "dependencies": {
     "@babel/core": "^7.27.7",
+    "@babel/plugin-syntax-typescript": "^7.27.1",
     "@babel/plugin-transform-typescript": "^7.27.1",
     "@rolldown/pluginutils": "^1.0.0-beta.21",
     "@vue/babel-plugin-jsx": "^1.4.0"

--- a/packages/plugin-vue-jsx/src/types.ts
+++ b/packages/plugin-vue-jsx/src/types.ts
@@ -11,4 +11,6 @@ export interface Options extends VueJSXPluginOptions, FilterOptions {
   /** @default ['defineComponent'] */
   defineComponentName?: string[]
   tsPluginOptions?: any
+  /** @default 'babel' */
+  tsTransform?: 'babel' | 'built-in'
 }

--- a/playground/vue-jsx-ts-built-in/__tests__/vue-jsx-ts-built-in.spec.ts
+++ b/playground/vue-jsx-ts-built-in/__tests__/vue-jsx-ts-built-in.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'vitest'
+import { page } from '~utils'
+
+test('should render', async () => {
+  expect(await page.textContent('.decorators-ts')).toMatch('1')
+  expect(await page.textContent('.decorators-tsx')).toMatch('2')
+  expect(await page.textContent('.decorators-vue-ts')).toMatch('3')
+  expect(await page.textContent('.decorators-vue-tsx')).toMatch('4')
+  expect(await page.textContent('.decorators-legacy-ts')).toMatch('5')
+  expect(await page.textContent('.decorators-legacy-tsx')).toMatch('6')
+  expect(await page.textContent('.decorators-legacy-vue-ts')).toMatch('7')
+  expect(await page.textContent('.decorators-legacy-vue-tsx')).toMatch('8')
+})
+
+test('should update', async () => {
+  await page.click('.decorators-ts')
+  expect(await page.textContent('.decorators-ts')).toMatch('2')
+  await page.click('.decorators-tsx')
+  expect(await page.textContent('.decorators-tsx')).toMatch('3')
+  await page.click('.decorators-vue-ts')
+  expect(await page.textContent('.decorators-vue-ts')).toMatch('4')
+  await page.click('.decorators-vue-tsx')
+  expect(await page.textContent('.decorators-vue-tsx')).toMatch('5')
+  await page.click('.decorators-legacy-ts')
+  expect(await page.textContent('.decorators-legacy-ts')).toMatch('6')
+  await page.click('.decorators-legacy-tsx')
+  expect(await page.textContent('.decorators-legacy-tsx')).toMatch('7')
+  await page.click('.decorators-legacy-vue-ts')
+  expect(await page.textContent('.decorators-legacy-vue-ts')).toMatch('8')
+  await page.click('.decorators-legacy-vue-tsx')
+  expect(await page.textContent('.decorators-legacy-vue-tsx')).toMatch('9')
+})

--- a/playground/vue-jsx-ts-built-in/decorators-legacy/DecoratorsTs.ts
+++ b/playground/vue-jsx-ts-built-in/decorators-legacy/DecoratorsTs.ts
@@ -1,0 +1,36 @@
+import { defineComponent, h, ref } from 'vue'
+
+function methodDecorator(
+  target: unknown,
+  propertyKey: string,
+  descriptor: PropertyDescriptor,
+) {
+  const originalMethod = descriptor.value
+  descriptor.value = function () {
+    const result = originalMethod.call(this)
+    this.value.value += 1
+    return result
+  }
+}
+
+export default defineComponent(() => {
+  class Counter {
+    value = ref(5)
+
+    @methodDecorator
+    increment() {}
+  }
+
+  const counter = new Counter()
+  const inc = () => counter.increment()
+
+  return () =>
+    h(
+      'button',
+      {
+        class: 'decorators-legacy-ts',
+        onClick: inc,
+      },
+      `decorators legacy ts ${counter.value.value}`,
+    )
+})

--- a/playground/vue-jsx-ts-built-in/decorators-legacy/DecoratorsTsx.tsx
+++ b/playground/vue-jsx-ts-built-in/decorators-legacy/DecoratorsTsx.tsx
@@ -1,0 +1,32 @@
+import { defineComponent, ref } from 'vue'
+
+function methodDecorator(
+  target: unknown,
+  propertyKey: string,
+  descriptor: PropertyDescriptor,
+) {
+  const originalMethod = descriptor.value
+  descriptor.value = function () {
+    const result = originalMethod.call(this)
+    this.value.value += 1
+    return result
+  }
+}
+
+export default defineComponent(() => {
+  class Counter {
+    value = ref(6)
+
+    @methodDecorator
+    increment() {}
+  }
+
+  const counter = new Counter()
+  const inc = () => counter.increment()
+
+  return () => (
+    <button class="decorators-legacy-tsx" onClick={inc}>
+      {`decorators legacy tsx ${counter.value.value}`}
+    </button>
+  )
+})

--- a/playground/vue-jsx-ts-built-in/decorators-legacy/DecoratorsVueTs.vue
+++ b/playground/vue-jsx-ts-built-in/decorators-legacy/DecoratorsVueTs.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { defineComponent, h, ref } from 'vue'
+
+function methodDecorator(
+  target: unknown,
+  propertyKey: string,
+  descriptor: PropertyDescriptor,
+) {
+  const originalMethod = descriptor.value
+  descriptor.value = function () {
+    const result = originalMethod.call(this)
+    this.value.value += 1
+    return result
+  }
+}
+
+const Component = defineComponent(() => {
+  class Counter {
+    value = ref(7)
+
+    @methodDecorator
+    increment() {}
+  }
+
+  const counter = new Counter()
+  const inc = () => counter.increment()
+
+  return () =>
+    h(
+      'button',
+      {
+        class: 'decorators-legacy-vue-ts',
+        onClick: inc,
+      },
+      `decorators legacy vue ts ${counter.value.value}`,
+    )
+})
+</script>
+<template>
+  <Component />
+</template>

--- a/playground/vue-jsx-ts-built-in/decorators-legacy/DecoratorsVueTsx.vue
+++ b/playground/vue-jsx-ts-built-in/decorators-legacy/DecoratorsVueTsx.vue
@@ -1,0 +1,37 @@
+<script setup lang="tsx">
+import { defineComponent, h, ref } from 'vue'
+
+function methodDecorator(
+  target: unknown,
+  propertyKey: string,
+  descriptor: PropertyDescriptor,
+) {
+  const originalMethod = descriptor.value
+  descriptor.value = function () {
+    const result = originalMethod.call(this)
+    this.value.value += 1
+    return result
+  }
+}
+
+const Component = defineComponent(() => {
+  class Counter {
+    value = ref(8)
+
+    @methodDecorator
+    increment() {}
+  }
+
+  const counter = new Counter()
+  const inc = () => counter.increment()
+
+  return () => (
+    <button class="decorators-legacy-vue-tsx" onClick={inc}>
+      {`decorators legacy vue tsx ${counter.value.value}`}
+    </button>
+  )
+})
+</script>
+<template>
+  <Component />
+</template>

--- a/playground/vue-jsx-ts-built-in/decorators-legacy/tsconfig.json
+++ b/playground/vue-jsx-ts-built-in/decorators-legacy/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "es2020",
+    "experimentalDecorators": true
+  }
+}

--- a/playground/vue-jsx-ts-built-in/decorators/DecoratorsTs.ts
+++ b/playground/vue-jsx-ts-built-in/decorators/DecoratorsTs.ts
@@ -1,0 +1,31 @@
+import { defineComponent, h, ref } from 'vue'
+
+function methodDecorator(originalMethod: () => void, context: unknown) {
+  return function (this: { value: { value: number } }) {
+    const result = originalMethod.call(this)
+    this.value.value += 1
+    return result
+  }
+}
+
+export default defineComponent(() => {
+  class Counter {
+    value = ref(1)
+
+    @methodDecorator
+    increment() {}
+  }
+
+  const counter = new Counter()
+  const inc = () => counter.increment()
+
+  return () =>
+    h(
+      'button',
+      {
+        class: 'decorators-ts',
+        onClick: inc,
+      },
+      `decorators ts ${counter.value.value}`,
+    )
+})

--- a/playground/vue-jsx-ts-built-in/decorators/DecoratorsTsx.tsx
+++ b/playground/vue-jsx-ts-built-in/decorators/DecoratorsTsx.tsx
@@ -1,0 +1,27 @@
+import { defineComponent, ref } from 'vue'
+
+function methodDecorator(originalMethod: () => void, context: unknown) {
+  return function (this: { value: { value: number } }) {
+    const result = originalMethod.call(this)
+    this.value.value += 1
+    return result
+  }
+}
+
+export default defineComponent(() => {
+  class Counter {
+    value = ref(2)
+
+    @methodDecorator
+    increment() {}
+  }
+
+  const counter = new Counter()
+  const inc = () => counter.increment()
+
+  return () => (
+    <button class="decorators-tsx" onClick={inc}>
+      {`decorators tsx ${counter.value.value}`}
+    </button>
+  )
+})

--- a/playground/vue-jsx-ts-built-in/decorators/DecoratorsVueTs.vue
+++ b/playground/vue-jsx-ts-built-in/decorators/DecoratorsVueTs.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { defineComponent, h, ref } from 'vue'
+
+function methodDecorator(originalMethod: () => void, context: unknown) {
+  return function (this: { value: { value: number } }) {
+    const result = originalMethod.call(this)
+    this.value.value += 1
+    return result
+  }
+}
+
+const Component = defineComponent(() => {
+  class Counter {
+    value = ref(3)
+
+    @methodDecorator
+    increment() {}
+  }
+
+  const counter = new Counter()
+  const inc = () => counter.increment()
+
+  return () =>
+    h(
+      'button',
+      {
+        class: 'decorators-vue-ts',
+        onClick: inc,
+      },
+      `decorators vue ts ${counter.value.value}`,
+    )
+})
+</script>
+<template>
+  <Component />
+</template>

--- a/playground/vue-jsx-ts-built-in/decorators/DecoratorsVueTsx.vue
+++ b/playground/vue-jsx-ts-built-in/decorators/DecoratorsVueTsx.vue
@@ -1,0 +1,32 @@
+<script setup lang="tsx">
+import { defineComponent, h, ref } from 'vue'
+
+function methodDecorator(originalMethod: () => void, context: unknown) {
+  return function (this: { value: { value: number } }) {
+    const result = originalMethod.call(this)
+    this.value.value += 1
+    return result
+  }
+}
+
+const Component = defineComponent(() => {
+  class Counter {
+    value = ref(4)
+
+    @methodDecorator
+    increment() {}
+  }
+
+  const counter = new Counter()
+  const inc = () => counter.increment()
+
+  return () => (
+    <button class="decorators-vue-tsx" onClick={inc}>
+      {`decorators vue tsx ${counter.value.value}`}
+    </button>
+  )
+})
+</script>
+<template>
+  <Component />
+</template>

--- a/playground/vue-jsx-ts-built-in/decorators/tsconfig.json
+++ b/playground/vue-jsx-ts-built-in/decorators/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "es2020",
+    "experimentalDecorators": false
+  }
+}

--- a/playground/vue-jsx-ts-built-in/index.html
+++ b/playground/vue-jsx-ts-built-in/index.html
@@ -1,0 +1,2 @@
+<div id="app"></div>
+<script type="module" src="./main.jsx"></script>

--- a/playground/vue-jsx-ts-built-in/main.jsx
+++ b/playground/vue-jsx-ts-built-in/main.jsx
@@ -1,0 +1,26 @@
+import { createApp } from 'vue'
+import DecoratorsTs from './decorators/DecoratorsTs'
+import DecoratorsTsx from './decorators/DecoratorsTsx'
+import DecoratorsVueTs from './decorators/DecoratorsVueTs.vue'
+import DecoratorsVueTsx from './decorators/DecoratorsVueTsx.vue'
+import DecoratorsLegacyTs from './decorators-legacy/DecoratorsTs'
+import DecoratorsLegacyTsx from './decorators-legacy/DecoratorsTsx'
+import DecoratorsLegacyVueTs from './decorators-legacy/DecoratorsVueTs.vue'
+import DecoratorsLegacyVueTsx from './decorators-legacy/DecoratorsVueTsx.vue'
+
+function App() {
+  return (
+    <>
+      <DecoratorsTs />
+      <DecoratorsTsx />
+      <DecoratorsVueTs />
+      <DecoratorsVueTsx />
+      <DecoratorsLegacyTs />
+      <DecoratorsLegacyTsx />
+      <DecoratorsLegacyVueTs />
+      <DecoratorsLegacyVueTsx />
+    </>
+  )
+}
+
+createApp(App).mount('#app')

--- a/playground/vue-jsx-ts-built-in/package.json
+++ b/playground/vue-jsx-ts-built-in/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@vitejs/test-vue-jsx-decorators",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "catalog:"
+  },
+  "devDependencies": {
+    "@babel/plugin-syntax-decorators": "^7.27.1",
+    "@vitejs/plugin-vue": "workspace:*",
+    "@vitejs/plugin-vue-jsx": "workspace:*"
+  }
+}

--- a/playground/vue-jsx-ts-built-in/tsconfig.json
+++ b/playground/vue-jsx-ts-built-in/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "es2020"
+  }
+}

--- a/playground/vue-jsx-ts-built-in/vite.config.js
+++ b/playground/vue-jsx-ts-built-in/vite.config.js
@@ -1,0 +1,46 @@
+import { defineConfig } from 'vite'
+import vueJsxPlugin from '@vitejs/plugin-vue-jsx'
+import vuePlugin from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [
+    vueJsxPlugin({
+      include: [/\.tesx$/, /\.[jt]sx$/],
+      tsTransform: 'built-in',
+      babelPlugins: [
+        // to tests decorators we use only method decorators
+        // they have the same syntax in 'legacy' and in '2023-11'
+        ['@babel/plugin-syntax-decorators', { version: '2023-11' }],
+      ],
+    }),
+    vuePlugin(),
+    {
+      name: 'jsx-query-plugin',
+      transform(code, id) {
+        if (id.includes('?query=true')) {
+          return `
+import { createVNode as _createVNode } from "vue";
+import { defineComponent, ref } from 'vue';
+export default defineComponent(() => {
+  const count = ref(6);
+
+  const inc = () => count.value++;
+
+  return () => _createVNode("button", {
+    "class": "jsx-with-query",
+    "onClick": inc
+  }, [count.value]);
+});
+`
+        }
+      },
+    },
+  ],
+  build: {
+    // to make tests faster
+    minify: false,
+  },
+  optimizeDeps: {
+    disabled: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       '@babel/core':
         specifier: ^7.27.7
         version: 7.27.7
+      '@babel/plugin-syntax-typescript':
+        specifier: ^7.27.1
+        version: 7.27.1(@babel/core@7.27.7)
       '@babel/plugin-transform-typescript':
         specifier: ^7.27.1
         version: 7.27.1(@babel/core@7.27.7)
@@ -309,6 +312,22 @@ importers:
         specifier: 'catalog:'
         version: 3.5.17(typescript@5.8.3)
     devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: workspace:*
+        version: link:../../packages/plugin-vue
+      '@vitejs/plugin-vue-jsx':
+        specifier: workspace:*
+        version: link:../../packages/plugin-vue-jsx
+
+  playground/vue-jsx-decorators:
+    dependencies:
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.17(typescript@5.8.3)
+    devDependencies:
+      '@babel/plugin-syntax-decorators':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.27.7)
       '@vitejs/plugin-vue':
         specifier: workspace:*
         version: link:../../packages/plugin-vue
@@ -544,6 +563,12 @@ packages:
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2':
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-decorators@7.27.1':
+    resolution: {integrity: sha512-YMq8Z87Lhl8EGkmb0MwYkt36QnxC+fzCgrl66ereamPlYToRpIk5nUjKUY3QKLWq8mwUB1BgbeXcTJhZOCDg5A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -5046,6 +5071,11 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.7
 
+  '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.27.7)':
+    dependencies:
+      '@babel/core': 7.27.7
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.27.7)':
     dependencies:
       '@babel/core': 7.27.7
@@ -6535,7 +6565,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.17':
     dependencies:
-      '@babel/parser': 7.27.5
+      '@babel/parser': 7.27.7
       '@vue/shared': 3.5.17
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -6565,7 +6595,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.17':
     dependencies:
-      '@babel/parser': 7.27.5
+      '@babel/parser': 7.27.7
       '@vue/compiler-core': 3.5.17
       '@vue/compiler-dom': 3.5.17
       '@vue/compiler-ssr': 3.5.17


### PR DESCRIPTION
### Description

- Adds feature #556
- Adds documentation about `babelPlugins` and `tsPluginOptions` options

### Additional context

In the original issue description the proposed new option `tsTransform` had values `'esbuild'` and `'babel'`. The `'esbuild'` options was renamed to `'built-in'` because it describes semantics more clearly and `vite` is planning to integrate `rolldown` as `esbuild` replacement.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [X] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
