### PR TITLE
fix(hmr): ignore non-js modules

### DIFF
--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -43,7 +43,9 @@ export async function handleHotUpdate(
   const { descriptor } = createDescriptor(file, content, options, true)
 
   let needRerender = false
-  const affectedModules = new Set<ModuleNode | undefined>()
+  const affectedModules = new Set<ModuleNode | undefined>(
+    modules.filter((mod) => mod.type !== 'js'), // this plugin does not handle non-js modules
+  )
   const mainModule = getMainModule(modules)
   const templateModule = modules.find((m) => /type=template/.test(m.url))
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This plugin only handles js module nodes so this plugin should not filter out non-js modules nodes.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
