### PR TITLE
chore: remove code related to `splitVendorChunkPlugin`

### DIFF
--- a/playground/vue/vite.config.ts
+++ b/playground/vue/vite.config.ts
@@ -29,16 +29,6 @@ export default defineConfig({
     // to make tests faster
     minify: false,
     assetsInlineLimit: 100, // keep SVG as assets URL
-    rollupOptions: {
-      output: {
-        // Test splitVendorChunkPlugin composition
-        manualChunks(id) {
-          if (id.includes('src-import')) {
-            return 'src-import'
-          }
-        },
-      },
-    },
   },
   css: {
     modules: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Follow up to #589

fixes this ecosystem-ci failure: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/16640378447/job/47089473692

`manualChunks` breaks the execution order and the way rollup handles it and rolldown handles it is different.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
