### PR TITLE
test: remove deprecated `optimizeDeps.disabled: true`

### DIFF
--- a/playground/vue-jsx-ts-built-in/vite.config.js
+++ b/playground/vue-jsx-ts-built-in/vite.config.js
@@ -22,7 +22,4 @@ export default defineConfig({
     // to make tests faster
     minify: false,
   },
-  optimizeDeps: {
-    disabled: true,
-  },
 })

--- a/playground/vue-jsx/vite.config.js
+++ b/playground/vue-jsx/vite.config.js
@@ -34,7 +34,4 @@ export default defineComponent(() => {
     // to make tests faster
     minify: false,
   },
-  optimizeDeps: {
-    disabled: true,
-  },
 })


### PR DESCRIPTION
```
(!) Experimental optimizeDeps.disabled and deps pre-bundling during build were removed in Vite 5.1.
    To disable the deps optimizer, set optimizeDeps.noDiscovery to true and optimizeDeps.include as undefined or empty.
    Please remove optimizeDeps.disabled from your config.
```