### PR TITLE
feat(vue-jsx): use `oxc` option instead of `esbuild` option for rolldown-vite

### DIFF
--- a/packages/plugin-vue-jsx/src/index.ts
+++ b/packages/plugin-vue-jsx/src/index.ts
@@ -65,10 +65,12 @@ function vueJsxPlugin(options: Options = {}): Plugin {
           return v
         }
       }
+      const isRolldownVite = this && 'rolldownVersion' in this.meta
+      const esbuildKey = (isRolldownVite ? 'oxc' : 'esbuild') as 'esbuild'
       return {
         // only apply esbuild to ts files
         // since we are handling jsx and tsx now
-        esbuild:
+        [esbuildKey]:
           tsTransform === 'built-in'
             ? {
                 // For 'built-in' we still need esbuild to transform ts syntax for `.tsx` files.
@@ -89,12 +91,11 @@ function vueJsxPlugin(options: Options = {}): Plugin {
               config.define?.__VUE_PROD_HYDRATION_MISMATCH_DETAILS__,
             ) ?? false,
         },
-        optimizeDeps:
-          this && 'rolldownVersion' in this.meta
-            ? {
-                rolldownOptions: { transform: { jsx: 'preserve' } },
-              }
-            : {},
+        optimizeDeps: isRolldownVite
+          ? {
+              rolldownOptions: { transform: { jsx: 'preserve' } },
+            }
+          : {},
       }
     },
 


### PR DESCRIPTION
### Description

close #719

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
