### PR TITLE
feat: use carets for `@rolldown/pluginutils` version

### DIFF
--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -51,7 +51,7 @@
     "vue": "catalog:"
   },
   "dependencies": {
-    "@rolldown/pluginutils": "1.0.1"
+    "@rolldown/pluginutils": "^1.0.1"
   },
   "compatiblePackages": {
     "schemaVersion": 1,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,7 +102,7 @@ importers:
   packages/plugin-vue:
     dependencies:
       '@rolldown/pluginutils':
-        specifier: 1.0.1
+        specifier: ^1.0.1
         version: 1.0.1
     devDependencies:
       '@babel/types':


### PR DESCRIPTION
So that the package manager can dedupe