### PR TITLE
refactor: use environment consumer to detect SSR

### DIFF
--- a/packages/plugin-vue-jsx/src/index.ts
+++ b/packages/plugin-vue-jsx/src/index.ts
@@ -158,7 +158,7 @@ function vueJsxPlugin(options: Options = {}): Plugin {
         },
       },
       async handler(code, id, opt) {
-        const ssr = opt?.ssr === true
+        const ssr = this.environment.config.consumer === 'server'
         const [filepath] = id.split('?')
 
         // use id for script blocks in Vue SFCs (e.g. `App.vue?vue&type=script&lang.jsx`)

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -424,7 +424,7 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin<Api> {
           return helperCode
         }
 
-        const ssr = opt?.ssr === true
+        const ssr = this.environment.config.consumer === 'server'
 
         const { filename, query } = parseVueRequest(id)
 
@@ -463,7 +463,7 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin<Api> {
     transform: {
       // filter is set in options() hook
       handler(code, id, opt) {
-        const ssr = opt?.ssr === true
+        const ssr = this.environment.config.consumer === 'server'
         const { filename, query } = parseVueRequest(id)
 
         if (query.raw || query.url) {


### PR DESCRIPTION
Replace the deprecated `opt.ssr` transform option with `this.environment.config.consumer === 'server'` in both `plugin-vue` and `plugin-vue-jsx`.

The `ssr` flag on the transform hook options is deprecated in favor of the environment API. Using `environment.config.consumer` is the recommended way to determine whether the current transform runs in a server (SSR) environment.

https://vite.dev/changes/this-environment-in-hooks#migration-guide