### PR TITLE
ci: preview release add pm and commentWithDev options

### DIFF
--- a/.github/workflows/release-continuous.yml
+++ b/.github/workflows/release-continuous.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: Publish
         # zizmor: ignore[use-trusted-publishing]
-        run: pnpm dlx pkg-pr-new@0.0 publish --pnpm --compact './packages/*'
+        run: pnpm dlx pkg-pr-new@0.0 publish --pnpm --compact './packages/*' --packageManager=pnpm,npm,yarn --commentWithDev


### PR DESCRIPTION
Port the pkg-pr-new options from vitejs/vite#21225 and vitejs/vite#21584 to this repo's continuous release workflow:

- `--packageManager=pnpm,npm,yarn`: generate install commands for pnpm, npm and yarn so they are easy to copy regardless of the package manager a developer uses.
- `--commentWithDev`: include the `-D` flag in the generated install commands.

Refs: https://github.com/vitejs/vite/pull/21225, https://github.com/vitejs/vite/pull/21584