### PR TITLE
test: remove config CJS module vars assertion

### DIFF
--- a/playground/ssr-vue/vite.config.js
+++ b/playground/ssr-vue/vite.config.js
@@ -10,11 +10,6 @@ const nestedVirtualId = '\0' + nestedVirtualFile
 
 const base = '/test/'
 
-// preserve this to test loading __filename & __dirname in ESM as Vite polyfills them.
-// if Vite incorrectly load this file, node.js would error out.
-globalThis.__vite_test_filename = __filename
-globalThis.__vite_test_dirname = __dirname
-
 export default defineConfig(({ command, ssrBuild, isSsrBuild }) => ({
   base,
   plugins: [


### PR DESCRIPTION
Remove config CJS module vars assertion as it's a test for the Vite core feature.