### PR TITLE
fix: suppress customizable select warning

### DIFF
--- a/packages/plugin-vue/src/template.ts
+++ b/packages/plugin-vue/src/template.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import slash from 'slash'
 import type {
   CompilerOptions,
+  CompilerError,
   SFCDescriptor,
   SFCTemplateCompileOptions,
   SFCTemplateCompileResults,
@@ -93,9 +94,33 @@ export function compile(
   customElement: boolean,
 ) {
   resolveScript(descriptor, options, ssr, customElement)
+  const templateCompilerOptions = resolveTemplateCompilerOptions(
+    descriptor,
+    options,
+    filename,
+    ssr,
+  )
+  if (!templateCompilerOptions) {
+    return
+  }
+
+  const userOnWarn = templateCompilerOptions.compilerOptions?.onWarn
   const result = options.compiler.compileTemplate({
-    ...resolveTemplateCompilerOptions(descriptor, options, filename, ssr)!,
+    ...templateCompilerOptions,
     source: code,
+    compilerOptions: {
+      ...templateCompilerOptions.compilerOptions,
+      onWarn: (warning) => {
+        if (shouldIgnoreCustomizableSelectWarning(warning, code)) {
+          return
+        }
+        if (userOnWarn) {
+          userOnWarn(warning)
+        } else {
+          console.warn(`[Vue warn] ${warning.message}`)
+        }
+      },
+    },
   })
 
   if (result.errors.length) {
@@ -118,6 +143,35 @@ export function compile(
   }
 
   return result
+}
+
+function shouldIgnoreCustomizableSelectWarning(
+  warning: CompilerError,
+  source: string,
+) {
+  if (
+    !warning.message.includes(
+      'cannot be child of <option>, according to HTML specifications',
+    )
+  ) {
+    return false
+  }
+
+  const optionOffset = warning.loc?.start.offset
+  if (optionOffset == null) {
+    return false
+  }
+
+  const selectStart = source.lastIndexOf('<select', optionOffset)
+  if (selectStart < 0) {
+    return false
+  }
+
+  const selectContent = source.slice(selectStart, optionOffset)
+
+  return /<select\b[^>]*>(?:\s|<!--[\s\S]*?-->)*<button\b[\s\S]*?<selectedcontent\b[\s\S]*?<option\b/.test(
+    selectContent,
+  )
 }
 
 export function resolveTemplateCompilerOptions(

--- a/playground/vue/CustomizableSelect.vue
+++ b/playground/vue/CustomizableSelect.vue
@@ -1,0 +1,10 @@
+<template>
+  <select class="customizable-select">
+    <button>
+      <selectedcontent></selectedcontent>
+    </button>
+    <option value="test">
+      <span>test</span>
+    </option>
+  </select>
+</template>

--- a/playground/vue/Main.vue
+++ b/playground/vue/Main.vue
@@ -37,6 +37,7 @@
   <PreCompiledExternalScoped />
   <PreCompiledExternalCssModules />
   <ParserOptions />
+  <CustomizableSelect />
   <ExportTypeProps1 msg="msg" />
   <ExportTypeProps2 msg="msg" />
 </template>
@@ -69,6 +70,7 @@ import PreCompiled from './pre-compiled/foo.vue'
 import PreCompiledExternalScoped from './pre-compiled/external-scoped.vue'
 import PreCompiledExternalCssModules from './pre-compiled/external-cssmodules.vue'
 import ParserOptions from './ParserOptions.vue'
+import CustomizableSelect from './CustomizableSelect.vue'
 import HmrCircularReference from './HmrCircularReference.vue'
 import TreeShakeScopedStyle from './TreeShakeScopedStyle.vue'
 

--- a/playground/vue/__tests__/vue.spec.ts
+++ b/playground/vue/__tests__/vue.spec.ts
@@ -484,6 +484,13 @@ describe('template parse options', () => {
       'custom',
     )
   })
+
+  test('customizable select does not warn', async () => {
+    expect(await page.textContent('.customizable-select')).toMatch('test')
+    expect(serverLogs.join('\n')).not.toContain(
+      '<span> cannot be child of <option>',
+    )
+  })
 })
 
 test('scoped style should be tree-shakeable', async () => {


### PR DESCRIPTION
## What is this PR solving?

This PR fixes a false-positive warning for customizable `<select>` markup in `vite-plugin-vue`. Valid `<option>` content was being reported as invalid HTML even though it is allowed by the modern customizable select pattern.

Fixes #828

## What other alternatives have you explored?

I considered suppressing all `<option>` warnings, but that would be too broad. This change keeps the fix narrow and only filters the specific false-positive case.

## Are there any parts you think require more attention from reviewers?

Please review the warning-matching logic to make sure it only suppresses the customizable select case and does not hide unrelated compiler warnings.

## Tests

I added a regression fixture and a test that reproduces the customizable select case and verifies the warning is no longer emitted.