### PR TITLE
fix(plugin-vue): transpile TS in templates with empty script block

### DIFF
--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -28,7 +28,7 @@ import { isVaporMode } from './utils/vapor'
 import type { ResolvedOptions } from './index'
 
 const emptyScriptLangRE =
-  /<script[^>]*\slang=["']?(tsx?)\b[^>]*>\s*<\/script\s*>/
+  /<script[^>]*\slang\s*=\s*["']?(tsx?)\b[^>]*?(?:\/>|>\s*<\/script\s*>)/
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function transformMain(

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -27,6 +27,9 @@ import { EXPORT_HELPER_ID } from './helper'
 import { isVaporMode } from './utils/vapor'
 import type { ResolvedOptions } from './index'
 
+const emptyScriptLangRE =
+  /<script[^>]*\slang=["']?(tsx?)\b[^>]*>\s*<\/script\s*>/
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function transformMain(
   code: string,
@@ -276,7 +279,12 @@ export async function transformMain(
 
   // handle TS transpilation
   let resolvedCode = output.join('\n')
-  const lang = descriptor.scriptSetup?.lang || descriptor.script?.lang
+  const lang =
+    descriptor.scriptSetup?.lang ||
+    descriptor.script?.lang ||
+    // the SFC parser discards empty script blocks, but their lang still
+    // applies to the code generated from the template
+    emptyScriptLangRE.exec(code)?.[1]
 
   if (
     lang &&

--- a/playground/vue/EmptyScriptSetupTs.vue
+++ b/playground/vue/EmptyScriptSetupTs.vue
@@ -1,0 +1,6 @@
+<template>
+  <h2>empty script setup with lang="ts"</h2>
+  <div class="empty-script-setup-ts">{{ 'ok' as string }}</div>
+</template>
+
+<script setup lang="ts"></script>

--- a/playground/vue/EmptyScriptSetupTsSpaced.vue
+++ b/playground/vue/EmptyScriptSetupTsSpaced.vue
@@ -3,4 +3,5 @@
   <div class="empty-script-setup-ts-spaced">{{ 'ok' as string }}</div>
 </template>
 
-<script setup lang="ts"></script>
+<!-- prettier-ignore -->
+<script setup lang = "ts"></script>

--- a/playground/vue/EmptyScriptSetupTsSpaced.vue
+++ b/playground/vue/EmptyScriptSetupTsSpaced.vue
@@ -1,0 +1,6 @@
+<template>
+  <h2>empty script setup with lang = "ts"</h2>
+  <div class="empty-script-setup-ts-spaced">{{ 'ok' as string }}</div>
+</template>
+
+<script setup lang="ts"></script>

--- a/playground/vue/Main.vue
+++ b/playground/vue/Main.vue
@@ -40,6 +40,8 @@
   <ExportTypeProps1 msg="msg" />
   <ExportTypeProps2 msg="msg" />
   <EmptyScriptSetupTs />
+  <EmptyScriptSetupTsSpaced />
+  <SelfClosingScriptSetupTs />
 </template>
 
 <script setup lang="ts">
@@ -81,6 +83,8 @@ function foo() {
 import ExportTypeProps1 from './ExportTypeProps1.vue'
 import ExportTypeProps2 from './ExportTypeProps2.vue'
 import EmptyScriptSetupTs from './EmptyScriptSetupTs.vue'
+import EmptyScriptSetupTsSpaced from './EmptyScriptSetupTsSpaced.vue'
+import SelfClosingScriptSetupTs from './SelfClosingScriptSetupTs.vue'
 
 const TsGeneric = defineAsyncComponent(() => import('./TsGeneric.vue'))
 

--- a/playground/vue/Main.vue
+++ b/playground/vue/Main.vue
@@ -39,6 +39,7 @@
   <ParserOptions />
   <ExportTypeProps1 msg="msg" />
   <ExportTypeProps2 msg="msg" />
+  <EmptyScriptSetupTs />
 </template>
 
 <script setup lang="ts">
@@ -79,6 +80,7 @@ function foo() {
 
 import ExportTypeProps1 from './ExportTypeProps1.vue'
 import ExportTypeProps2 from './ExportTypeProps2.vue'
+import EmptyScriptSetupTs from './EmptyScriptSetupTs.vue'
 
 const TsGeneric = defineAsyncComponent(() => import('./TsGeneric.vue'))
 

--- a/playground/vue/SelfClosingScriptSetupTs.vue
+++ b/playground/vue/SelfClosingScriptSetupTs.vue
@@ -1,0 +1,6 @@
+<template>
+  <h2>self-closing script setup with lang="ts"</h2>
+  <div class="self-closing-script-setup-ts">{{ 'ok' as string }}</div>
+</template>
+
+<script setup lang="ts" />

--- a/playground/vue/__tests__/vue.spec.ts
+++ b/playground/vue/__tests__/vue.spec.ts
@@ -30,6 +30,10 @@ test('template/script latest syntax support', async () => {
   expect(await page.textContent('.syntax')).toBe('baz')
 })
 
+test('template ts syntax support with empty script setup', async () => {
+  expect(await page.textContent('.empty-script-setup-ts')).toBe('ok')
+})
+
 test('import ts with .js extension with lang="ts"', async () => {
   expect(await page.textContent('.ts-import')).toBe('success')
   expect(await page.textContent('.ts-import2')).toBe('success')

--- a/playground/vue/__tests__/vue.spec.ts
+++ b/playground/vue/__tests__/vue.spec.ts
@@ -32,6 +32,8 @@ test('template/script latest syntax support', async () => {
 
 test('template ts syntax support with empty script setup', async () => {
   expect(await page.textContent('.empty-script-setup-ts')).toBe('ok')
+  expect(await page.textContent('.empty-script-setup-ts-spaced')).toBe('ok')
+  expect(await page.textContent('.self-closing-script-setup-ts')).toBe('ok')
 })
 
 test('import ts with .js extension with lang="ts"', async () => {


### PR DESCRIPTION
encountered this when testing https://github.com/nuxt/nuxt/pull/36258 (which entailed creating deliberate errors to make vite complain 😆)